### PR TITLE
Board v20190608

### DIFF
--- a/BOM.md
+++ b/BOM.md
@@ -4,7 +4,7 @@
 |:-----------------|:-------------|:---------------------------|---------:|-----------:|------------:|
 | Cherry MX Switch | Through Hole | [540-MX1A-E1NW][1]         |       12 |     $0.840 |     $10.080 |
 | 1N4148 Diode     | Through Hole | [512-1N4148][2]            |       12 |     $0.174 |      $2.088 |
-| ATMEGA32U4RC-AU  | TQFP-44      | [556-ATMEGA32U4RC-AU][3]   |        1 |     $4.090 |      $4.090 |
+| ATMEGA32U4-AU    | TQFP-44      | [556-ATMEGA32U4-AU][3]     |        1 |     $4.090 |      $4.090 |
 | 16MHz Crystal    | 3.2x5        | [520-160-18-30B-AGNT][4]   |        1 |     $0.580 |      $0.580 |
 | 22p Cap          | 0603         | [80-C0603C220J5G7411][5]   |        2 |     $0.104 |      $0.208 |
 | 4.7u Cap         | 0603         | [963-LMK107BJ475MAHT][6]   |        1 |     $0.110 |      $0.110 |
@@ -19,7 +19,7 @@
 
 [1]: https://www.mouser.com/ProductDetail/540-MX1A-E1NW
 [2]: https://www.mouser.com/ProductDetail/512-1N4148
-[3]: https://www.mouser.com/ProductDetail/556-ATMEGA32U4RC-AU
+[3]: https://www.mouser.com/ProductDetail/556-ATMEGA32U4-AU
 [4]: https://www.mouser.com/ProductDetail/520-160-18-30B-AGNT
 [5]: https://www.mouser.com/ProductDetail/80-C0603C220J5G7411
 [6]: https://www.mouser.com/ProductDetail/963-LMK107BJ475MAHT

--- a/BOM.md
+++ b/BOM.md
@@ -5,8 +5,8 @@
 | Cherry MX Switch | Through Hole |                   |       12 |     $0.840 |     $10.080 |
 | 1N4148 Diode     | Through Hole | [512-1N4148](https://www.mouser.com/ProductDetail/ON-Semiconductor-Fairchild/1N4148?qs=sGAEpiMZZMudZehw8RjeZWbu6z6oTQTL) |       12 |     $0.174 |      $2.088 |
 | ATMEGA32U4RC-AU  | TQFP-44      | [556-ATMEGA32U4RC-AU](https://www.mouser.com/ProductDetail/Microchip-Technology-Atmel/ATMEGA32U4RC-AU?qs=sGAEpiMZZMsYqpeQgG6TRW%252BiA%252BrYIJEZ) |        1 |     $4.090 |      $4.090 |
-| 16MHz Crystal    | 3.2x2.5      |                   |        1 |     $0.340 |      $0.340 |
-| 22p Cap          | 0603         |                   |        2 |     $0.104 |      $0.208 |
+| 16MHz Crystal    | 3.2x5        | [520-160-18-30B-AGNT](https://www.mouser.com/ProductDetail/ECS/ECS-160-18-30B-AGN-TR?qs=sGAEpiMZZMsBj6bBr9Q9abMK2mGYOCsJLoYFKfO8TbxdXrUHsCnSMQ%3D%3D) |        1 |     $0.580 |      $0.580 |
+| 22p Cap          | 0603         | [80-C0603C220J5G7411](https://www.mouser.com/ProductDetail/80-C0603C220J5G7411) |        2 |     $0.104 |      $0.208 |
 | 4.7u Cap         | 0603         |                   |        1 |     $0.110 |      $0.110 |
 | 1u Cap           | 0603         |                   |        1 |     $0.215 |      $0.215 |
 | 0.1u Cap         | 0603         |                   |        5 |     $0.073 |      $0.365 |
@@ -15,4 +15,4 @@
 | Switch           | EVQP2        |                   |        1 |     $0.750 |      $0.750 |
 | Ferrite Bead     | 0805         |                   |        1 |     $0.250 |      $0.250 |
 | USB Mini Female  |              | [798-UX60-MB-5S8](https://www.mouser.com/ProductDetail/Hirose-Connector/UX60-MB-5S8?qs=sGAEpiMZZMvFp%252ByPHbnZYxQQq4fviyhW) |        1 |     $1.530 |      $1.530 |
-|                  |              |                   |          |            |     $18.798 |
+|                  |              |                   |          |            |     $19.038 |

--- a/BOM.md
+++ b/BOM.md
@@ -1,18 +1,32 @@
 # Bill of Materials
 
-| Item             | Package      | Mouser Product ID | Quantity | Unit Price | Total Price |
-|:-----------------|:-------------|:------------------|---------:|-----------:|------------:|
-| Cherry MX Switch | Through Hole |                   |       12 |     $0.840 |     $10.080 |
-| 1N4148 Diode     | Through Hole | [512-1N4148](https://www.mouser.com/ProductDetail/ON-Semiconductor-Fairchild/1N4148?qs=sGAEpiMZZMudZehw8RjeZWbu6z6oTQTL) |       12 |     $0.174 |      $2.088 |
-| ATMEGA32U4RC-AU  | TQFP-44      | [556-ATMEGA32U4RC-AU](https://www.mouser.com/ProductDetail/Microchip-Technology-Atmel/ATMEGA32U4RC-AU?qs=sGAEpiMZZMsYqpeQgG6TRW%252BiA%252BrYIJEZ) |        1 |     $4.090 |      $4.090 |
-| 16MHz Crystal    | 3.2x5        | [520-160-18-30B-AGNT](https://www.mouser.com/ProductDetail/ECS/ECS-160-18-30B-AGN-TR?qs=sGAEpiMZZMsBj6bBr9Q9abMK2mGYOCsJLoYFKfO8TbxdXrUHsCnSMQ%3D%3D) |        1 |     $0.580 |      $0.580 |
-| 22p Cap          | 0603         | [80-C0603C220J5G7411](https://www.mouser.com/ProductDetail/80-C0603C220J5G7411) |        2 |     $0.104 |      $0.208 |
-| 4.7u Cap         | 0603         |                   |        1 |     $0.110 |      $0.110 |
-| 1u Cap           | 0603         |                   |        1 |     $0.215 |      $0.215 |
-| 0.1u Cap         | 0603         |                   |        5 |     $0.073 |      $0.365 |
-| 10K Resistor     | 0603         |                   |        2 |     $0.065 |      $0.130 |
-| 22 Resistor      | 0603         |                   |        2 |     $0.036 |      $0.072 |
-| Switch           | EVQP2        |                   |        1 |     $0.750 |      $0.750 |
-| Ferrite Bead     | 0805         |                   |        1 |     $0.250 |      $0.250 |
-| USB Mini Female  |              | [798-UX60-MB-5S8](https://www.mouser.com/ProductDetail/Hirose-Connector/UX60-MB-5S8?qs=sGAEpiMZZMvFp%252ByPHbnZYxQQq4fviyhW) |        1 |     $1.530 |      $1.530 |
-|                  |              |                   |          |            |     $19.038 |
+| Item             | Package      | Mouser Product ID          | Quantity | Unit Price | Total Price |
+|:-----------------|:-------------|:---------------------------|---------:|-----------:|------------:|
+| Cherry MX Switch | Through Hole | [540-MX1A-E1NW][1]         |       12 |     $0.840 |     $10.080 |
+| 1N4148 Diode     | Through Hole | [512-1N4148][2]            |       12 |     $0.174 |      $2.088 |
+| ATMEGA32U4RC-AU  | TQFP-44      | [556-ATMEGA32U4RC-AU][3]   |        1 |     $4.090 |      $4.090 |
+| 16MHz Crystal    | 3.2x5        | [520-160-18-30B-AGNT][4]   |        1 |     $0.580 |      $0.580 |
+| 22p Cap          | 0603         | [80-C0603C220J5G7411][5]   |        2 |     $0.104 |      $0.208 |
+| 4.7u Cap         | 0603         | [963-LMK107BJ475MAHT][6]   |        1 |     $0.110 |      $0.110 |
+| 1u Cap           | 0603         | [963-TMK107BLD105MA-T][7]  |        1 |     $0.215 |      $0.215 |
+| 0.1u Cap         | 0603         | [80-C0603C104J4RECLR][8]   |        5 |     $0.073 |      $0.365 |
+| 10K Resistor     | 0603         | [71-CRCW060310K0FKEAC][9]  |        2 |     $0.065 |      $0.130 |
+| 22 Resistor      | 0603         | [71-CRCW060322R0FKEAC][10] |        2 |     $0.036 |      $0.072 |
+| Switch           | EVQP2        | [667-EVQ-P2602W][11]       |        1 |     $0.750 |      $0.750 |
+| Ferrite Bead     | 0805         | [81-BLM21SP471SH1D][12]    |        1 |     $0.250 |      $0.250 |
+| USB Mini Female  |              | [798-UX60-MB-5S8][13]      |        1 |     $1.530 |      $1.530 |
+|                  |              |                            |          |            |     $19.038 |
+
+[1]: https://www.mouser.com/ProductDetail/540-MX1A-E1NW
+[2]: https://www.mouser.com/ProductDetail/512-1N4148
+[3]: https://www.mouser.com/ProductDetail/556-ATMEGA32U4RC-AU
+[4]: https://www.mouser.com/ProductDetail/520-160-18-30B-AGNT
+[5]: https://www.mouser.com/ProductDetail/80-C0603C220J5G7411
+[6]: https://www.mouser.com/ProductDetail/963-LMK107BJ475MAHT
+[7]: https://www.mouser.com/ProductDetail/963-TMK107BLD105MA-T
+[8]: https://www.mouser.com/ProductDetail/80-C0603C104J4RECLR
+[9]: https://www.mouser.com/ProductDetail/71-CRCW060310K0FKEAC
+[10]: https://www.mouser.com/ProductDetail/71-CRCW060322R0FKEAC
+[11]: https://www.mouser.com/ProductDetail/667-EVQ-P2602W
+[12]: https://www.mouser.com/ProductDetail/81-BLM21SP471SH1D
+[13]: https://www.mouser.com/ProductDetail/798-UX60-MB-5S8

--- a/BOM.md
+++ b/BOM.md
@@ -4,7 +4,7 @@
 |:-----------------|:-------------|:------------------|---------:|-----------:|------------:|
 | Cherry MX Switch | Through Hole |                   |       12 |     $0.840 |     $10.080 |
 | 1N4148 Diode     | Through Hole | [512-1N4148](https://www.mouser.com/ProductDetail/ON-Semiconductor-Fairchild/1N4148?qs=sGAEpiMZZMudZehw8RjeZWbu6z6oTQTL) |       12 |     $0.174 |      $2.088 |
-| ATMEGA32U4-MU    | QFN44        |                   |        1 |     $4.090 |      $4.090 |
+| ATMEGA32U4RC-AU  | TQFP-44      | [556-ATMEGA32U4RC-AU](https://www.mouser.com/ProductDetail/Microchip-Technology-Atmel/ATMEGA32U4RC-AU?qs=sGAEpiMZZMsYqpeQgG6TRW%252BiA%252BrYIJEZ) |        1 |     $4.090 |      $4.090 |
 | 16MHz Crystal    | 3.2x2.5      |                   |        1 |     $0.340 |      $0.340 |
 | 22p Cap          | 0603         |                   |        2 |     $0.104 |      $0.208 |
 | 4.7u Cap         | 0603         |                   |        1 |     $0.110 |      $0.110 |

--- a/BOM.md
+++ b/BOM.md
@@ -1,18 +1,18 @@
 # Bill of Materials
 
-| Item             | Package      | Quantity | Unit Price | Total Price |
-|:-----------------|:-------------|---------:|-----------:|------------:|
-| Cherry MX Switch | Through Hole |       12 |     $0.840 |     $10.080 |
-| Diode            | 0603         |       12 |     $0.174 |      $2.088 |
-| ATMEGA32U4-MU    | QFN44        |        1 |     $4.090 |      $4.090 |
-| 16MHz Crystal    | 3.2x2.5      |        1 |     $0.340 |      $0.340 |
-| 22p Cap          | 0603         |        2 |     $0.104 |      $0.208 |
-| 4.7u Cap         | 0603         |        1 |     $0.110 |      $0.110 |
-| 1u Cap           | 0603         |        1 |     $0.215 |      $0.215 |
-| 0.1u Cap         | 0603         |        5 |     $0.073 |      $0.365 |
-| 10K Resistor     | 0603         |        2 |     $0.065 |      $0.130 |
-| 22 Resistor      | 0603         |        2 |     $0.036 |      $0.072 |
-| Switch           | EVQP2        |        1 |     $0.750 |      $0.750 |
-| Ferrite Bead     | 0805         |        1 |     $0.250 |      $0.250 |
-| USB Mini Female  |              |        1 |     $1.530 |      $1.530 |
-|                  |              |          |            |     $18.798 |
+| Item             | Package      | Mouser Product ID | Quantity | Unit Price | Total Price |
+|:-----------------|:-------------|:------------------|---------:|-----------:|------------:|
+| Cherry MX Switch | Through Hole |                   |       12 |     $0.840 |     $10.080 |
+| 1N4148 Diode     | Through Hole | [512-1N4148](https://www.mouser.com/ProductDetail/ON-Semiconductor-Fairchild/1N4148?qs=sGAEpiMZZMudZehw8RjeZWbu6z6oTQTL) |       12 |     $0.174 |      $2.088 |
+| ATMEGA32U4-MU    | QFN44        |                   |        1 |     $4.090 |      $4.090 |
+| 16MHz Crystal    | 3.2x2.5      |                   |        1 |     $0.340 |      $0.340 |
+| 22p Cap          | 0603         |                   |        2 |     $0.104 |      $0.208 |
+| 4.7u Cap         | 0603         |                   |        1 |     $0.110 |      $0.110 |
+| 1u Cap           | 0603         |                   |        1 |     $0.215 |      $0.215 |
+| 0.1u Cap         | 0603         |                   |        5 |     $0.073 |      $0.365 |
+| 10K Resistor     | 0603         |                   |        2 |     $0.065 |      $0.130 |
+| 22 Resistor      | 0603         |                   |        2 |     $0.036 |      $0.072 |
+| Switch           | EVQP2        |                   |        1 |     $0.750 |      $0.750 |
+| Ferrite Bead     | 0805         |                   |        1 |     $0.250 |      $0.250 |
+| USB Mini Female  |              | [798-UX60-MB-5S8](https://www.mouser.com/ProductDetail/Hirose-Connector/UX60-MB-5S8?qs=sGAEpiMZZMvFp%252ByPHbnZYxQQq4fviyhW) |        1 |     $1.530 |      $1.530 |
+|                  |              |                   |          |            |     $18.798 |

--- a/PCB/MacroPad.brd
+++ b/PCB/MacroPad.brd
@@ -179,27 +179,6 @@
 <rectangle x1="-0.8" y1="-0.4" x2="-0.45" y2="0.4" layer="51"/>
 <rectangle x1="0.45" y1="-0.4" x2="0.8" y2="0.4" layer="51"/>
 </package>
-<package name="CRYSTAL-3.2X2.5">
-<smd name="3" x="1.15" y="0.925" dx="1.3" dy="1.05" layer="1"/>
-<smd name="2" x="1.15" y="-0.925" dx="1.3" dy="1.05" layer="1"/>
-<smd name="1" x="-1.15" y="-0.925" dx="1.3" dy="1.05" layer="1"/>
-<smd name="4" x="-1.15" y="0.925" dx="1.3" dy="1.05" layer="1"/>
-<rectangle x1="-1.8" y1="-1.4" x2="1.8" y2="1.4" layer="39"/>
-<wire x1="-1.6" y1="0.15" x2="-1.6" y2="-0.15" width="0.127" layer="47"/>
-<wire x1="1.6" y1="0.15" x2="1.6" y2="-0.15" width="0.127" layer="47"/>
-<wire x1="-0.3" y1="-1.25" x2="0.3" y2="-1.25" width="0.127" layer="47"/>
-<wire x1="-0.3" y1="1.25" x2="0.3" y2="1.25" width="0.127" layer="47"/>
-<wire x1="-1.9" y1="1.55" x2="-1.1" y2="1.55" width="0.127" layer="21"/>
-<wire x1="-1.9" y1="1.55" x2="-1.9" y2="0.4" width="0.127" layer="21"/>
-<wire x1="-1.9" y1="-0.4" x2="-1.9" y2="-1.55" width="0.127" layer="21"/>
-<wire x1="-1.9" y1="-1.55" x2="-1.1" y2="-1.55" width="0.127" layer="21"/>
-<wire x1="1.1" y1="-1.55" x2="1.9" y2="-1.55" width="0.127" layer="21"/>
-<wire x1="1.9" y1="-1.55" x2="1.9" y2="-0.8" width="0.127" layer="21"/>
-<wire x1="1.1" y1="1.55" x2="1.9" y2="1.55" width="0.127" layer="21"/>
-<wire x1="1.9" y1="1.55" x2="1.9" y2="0.8" width="0.127" layer="21"/>
-<text x="0" y="1.65" size="1.27" layer="21" font="vector" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1.65" size="1.27" layer="21" font="vector" align="top-center">&gt;VALUE</text>
-</package>
 </packages>
 </library>
 <library name="USB">
@@ -358,6 +337,24 @@
 <rectangle x1="5.95" y1="-1.3" x2="6.85" y2="1.3" layer="39"/>
 <hole x="6.4" y="-1.75" drill="0.9"/>
 <hole x="6.4" y="1.75" drill="0.9"/>
+</package>
+<package name="CRYSTAL-3.2X5">
+<description>3.2 x 5 mm crystal</description>
+<smd name="3" x="2" y="1.2" dx="1.8" dy="1.2" layer="1"/>
+<smd name="2" x="2" y="-1.2" dx="1.8" dy="1.2" layer="1"/>
+<smd name="1" x="-2" y="-1.2" dx="1.8" dy="1.2" layer="1"/>
+<smd name="4" x="-2" y="1.2" dx="1.8" dy="1.2" layer="1"/>
+<rectangle x1="-2.6" y1="-1.7" x2="2.6" y2="1.7" layer="39"/>
+<wire x1="-3.125" y1="2" x2="-1.1" y2="2" width="0.127" layer="21"/>
+<wire x1="-3.125" y1="2" x2="-3.125" y2="0.75" width="0.127" layer="21"/>
+<wire x1="-3.125" y1="-0.75" x2="-3.125" y2="-2" width="0.127" layer="21"/>
+<wire x1="-3.125" y1="-2" x2="-1.1" y2="-2" width="0.127" layer="21"/>
+<wire x1="1.1" y1="-2" x2="3.125" y2="-2" width="0.127" layer="21"/>
+<wire x1="3.125" y1="-2" x2="3.125" y2="-0.75" width="0.127" layer="21"/>
+<wire x1="1.1" y1="2" x2="3.125" y2="2" width="0.127" layer="21"/>
+<wire x1="3.125" y1="2" x2="3.125" y2="0.75" width="0.127" layer="21"/>
+<text x="0" y="2.25" size="1.27" layer="21" font="vector" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-2.25" size="1.27" layer="21" font="vector" align="top-center">&gt;VALUE</text>
 </package>
 </packages>
 </library>
@@ -821,17 +818,17 @@ design rules under a new name.</description>
 </pass>
 </autorouter>
 <elements>
-<element name="C1" library="Components" package="C0603" value="22p" x="17.018" y="27.559" smashed="yes" rot="R90">
-<attribute name="MF" value="" x="17.018" y="27.559" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="MPN" value="04025A220JAT2A" x="17.018" y="27.559" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="NAME" x="17.638" y="27.521" size="1" layer="25" ratio="13" rot="R90" align="top-center"/>
-<attribute name="OC_NEWARK" value="96M1143" x="17.018" y="27.559" size="1.778" layer="27" rot="R90" display="off"/>
+<element name="C1" library="Components" package="C0603" value="22p" x="13.97" y="26.67" smashed="yes" rot="R90">
+<attribute name="MF" value="" x="13.97" y="26.67" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MPN" value="04025A220JAT2A" x="13.97" y="26.67" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="NAME" x="14.59" y="26.632" size="1" layer="25" ratio="13" rot="R90" align="top-center"/>
+<attribute name="OC_NEWARK" value="96M1143" x="13.97" y="26.67" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="C2" library="Components" package="C0603" value="22p" x="10.668" y="27.559" smashed="yes" rot="R270">
-<attribute name="MF" value="" x="10.668" y="27.559" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="MPN" value="04025A220JAT2A" x="10.668" y="27.559" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="NAME" x="9.921" y="27.597" size="1" layer="25" ratio="13" rot="R270" align="top-center"/>
-<attribute name="OC_NEWARK" value="96M1143" x="10.668" y="27.559" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="C2" library="Components" package="C0603" value="22p" x="5.08" y="26.67" smashed="yes" rot="R270">
+<attribute name="MF" value="" x="5.08" y="26.67" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MPN" value="04025A220JAT2A" x="5.08" y="26.67" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="4.333" y="26.708" size="1" layer="25" ratio="13" rot="R270" align="top-center"/>
+<attribute name="OC_NEWARK" value="96M1143" x="5.08" y="26.67" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
 <element name="C3" library="Components" package="C0603" value="4.7u" x="4.953" y="46.101" smashed="yes" rot="R225">
 <attribute name="MF" value="" x="4.953" y="46.101" size="1.778" layer="27" rot="R225" display="off"/>
@@ -984,13 +981,6 @@ design rules under a new name.</description>
 <attribute name="OC_NEWARK" value="unknown" x="9.525" y="76.2" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="VALUE" x="3.81" y="74.93" size="1.27" layer="27" rot="R270"/>
 </element>
-<element name="Y1" library="Components" package="CRYSTAL-3.2X2.5" value="" x="13.843" y="27.559" smashed="yes" rot="R180">
-<attribute name="MF" value="" x="13.843" y="27.559" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="MPN" value="" x="13.843" y="27.559" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="NAME" x="13.843" y="25.909" size="1.27" layer="21" font="vector" rot="R180" align="bottom-center"/>
-<attribute name="OC_NEWARK" value="unknown" x="13.843" y="27.559" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="VALUE" x="13.843" y="29.209" size="1.27" layer="21" font="vector" rot="R180" align="top-center"/>
-</element>
 <element name="C9" library="Components" package="C0603" value="0.1u" x="5.969" y="45.085" smashed="yes" rot="R226">
 <attribute name="MF" value="" x="5.969" y="45.085" size="1.778" layer="27" rot="R226" display="off"/>
 <attribute name="MPN" value="" x="5.969" y="45.085" size="1.778" layer="27" rot="R226" display="off"/>
@@ -1053,33 +1043,38 @@ design rules under a new name.</description>
 <attribute name="PACKAGE" value="TQFP-44 Microchip" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
 <attribute name="PRICE" value="None" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
 </element>
+<element name="Y1" library="Controller" package="CRYSTAL-3.2X5" value="" x="9.525" y="26.67" smashed="yes" rot="R180">
+<attribute name="NAME" x="9.525" y="24.42" size="1.27" layer="21" font="vector" rot="R180" align="bottom-center"/>
+<attribute name="VALUE" x="9.525" y="28.92" size="1.27" layer="21" font="vector" rot="R180" align="top-center"/>
+</element>
 </elements>
 <signals>
 <signal name="N$1">
-<contactref element="Y1" pad="3"/>
 <contactref element="C2" pad="2"/>
-<via x="12.7" y="25.273" extent="1-16" drill="0.3048"/>
-<wire x1="12.693" y1="26.634" x2="12.7" y2="26.627" width="0.254" layer="1"/>
-<wire x1="12.7" y1="26.627" x2="12.7" y2="25.273" width="0.254" layer="1"/>
-<wire x1="10.668" y1="26.684" x2="12.643" y2="26.684" width="0.254" layer="1"/>
-<wire x1="12.643" y1="26.684" x2="12.693" y2="26.634" width="0.254" layer="1"/>
 <contactref element="U1" pad="16"/>
-<wire x1="13.027296875" y1="33.484146875" x2="14.478" y2="32.03344375" width="0.254" layer="1"/>
-<wire x1="14.478" y1="32.03344375" x2="14.478" y2="29.972" width="0.254" layer="1"/>
-<via x="14.478" y="29.972" extent="1-16" drill="0.35"/>
-<wire x1="14.478" y1="29.972" x2="14.478" y2="25.781" width="0.254" layer="16"/>
-<wire x1="14.478" y1="25.781" x2="13.97" y2="25.273" width="0.254" layer="16"/>
-<wire x1="13.97" y1="25.273" x2="12.7" y2="25.273" width="0.254" layer="16"/>
+<wire x1="13.027296875" y1="33.484146875" x2="14.859" y2="31.65244375" width="0.254" layer="1"/>
+<contactref element="Y1" pad="3"/>
+<wire x1="7.525" y1="25.47" x2="7.2" y2="25.795" width="0.254" layer="1"/>
+<wire x1="7.2" y1="25.795" x2="5.08" y2="25.795" width="0.254" layer="1"/>
+<wire x1="14.859" y1="31.65244375" x2="14.859" y2="30.55913125" width="0.254" layer="1"/>
+<wire x1="14.859" y1="30.55913125" x2="13.3936" y2="29.09373125" width="0.254" layer="1"/>
+<wire x1="7.525" y1="25.47" x2="8.89" y2="25.47" width="0.254" layer="1"/>
+<wire x1="8.89" y1="25.47" x2="9.525" y2="26.105" width="0.254" layer="1"/>
+<wire x1="9.525" y1="26.105" x2="9.525" y2="28.321" width="0.254" layer="1"/>
+<wire x1="9.525" y1="28.321" x2="10.29773125" y2="29.09373125" width="0.254" layer="1"/>
+<wire x1="10.29773125" y1="29.09373125" x2="13.3936" y2="29.09373125" width="0.254" layer="1"/>
 </signal>
 <signal name="N$2">
-<contactref element="Y1" pad="1"/>
 <contactref element="C1" pad="2"/>
-<wire x1="14.993" y1="28.484" x2="15.24" y2="28.484" width="0.254" layer="1"/>
-<wire x1="15.24" y1="28.484" x2="16.968" y2="28.484" width="0.254" layer="1"/>
-<wire x1="16.968" y1="28.484" x2="17.018" y2="28.434" width="0.254" layer="1"/>
 <contactref element="U1" pad="17"/>
-<wire x1="13.584075" y1="34.040921875" x2="15.24" y2="32.384996875" width="0.254" layer="1"/>
-<wire x1="15.24" y1="32.384996875" x2="15.24" y2="28.484" width="0.254" layer="1"/>
+<contactref element="Y1" pad="1"/>
+<wire x1="13.584075" y1="34.040921875" x2="15.494" y2="32.130996875" width="0.254" layer="1"/>
+<wire x1="15.494" y1="32.130996875" x2="15.494" y2="28.956" width="0.254" layer="1"/>
+<wire x1="15.494" y1="28.956" x2="14.224" y2="27.686" width="0.254" layer="1"/>
+<wire x1="14.224" y1="27.686" x2="14.083" y2="27.545" width="0.254" layer="1"/>
+<wire x1="14.083" y1="27.545" x2="13.97" y2="27.545" width="0.254" layer="1"/>
+<wire x1="11.525" y1="27.87" x2="11.709" y2="27.686" width="0.254" layer="1"/>
+<wire x1="11.709" y1="27.686" x2="14.224" y2="27.686" width="0.254" layer="1"/>
 </signal>
 <signal name="VCC">
 <contactref element="C3" pad="1"/>
@@ -1102,13 +1097,11 @@ design rules under a new name.</description>
 <wire x1="11.125" y1="47.625" x2="11.125" y2="42.342" width="0.508" layer="16"/>
 <wire x1="11.633" y1="41.783" x2="11.125" y2="41.275" width="0.508" layer="16"/>
 <wire x1="11.125" y1="41.275" x2="8.55621875" y2="38.70621875" width="0.508" layer="16"/>
-<wire x1="8.55621875" y1="35.89378125" x2="6.96871875" y2="34.30628125" width="0.508" layer="16"/>
+<wire x1="8.55621875" y1="35.89378125" x2="8.048221875" y2="35.385784375" width="0.508" layer="16"/>
 <wire x1="10.938284375" y1="33.29028125" x2="10.938284375" y2="33.41728125" width="0.508" layer="16"/>
-<wire x1="10.938284375" y1="33.41728125" x2="8.86639375" y2="35.489175" width="0.508" layer="16"/>
-<wire x1="9.350784375" y1="35.00478125" x2="8.96978125" y2="35.385784375" width="0.508" layer="16"/>
+<wire x1="10.112784375" y1="34.24278125" x2="9.57221875" y2="34.78335" width="0.508" layer="16"/>
 <wire x1="8.96978125" y1="35.385784375" x2="8.55621875" y2="35.799346875" width="0.508" layer="16"/>
 <wire x1="8.55621875" y1="38.70621875" x2="8.55621875" y2="35.89378125" width="0.508" layer="16"/>
-<wire x1="8.55621875" y1="35.89378125" x2="8.55621875" y2="35.799346875" width="0.508" layer="16"/>
 <wire x1="2.159" y1="45.339" x2="2.159" y2="43.942" width="0.508" layer="1"/>
 <wire x1="2.159" y1="45.339" x2="4.428715625" y2="47.608715625" width="0.508" layer="1"/>
 <wire x1="4.682715625" y1="47.608715625" x2="5.08" y2="47.608715625" width="0.508" layer="1"/>
@@ -1116,20 +1109,20 @@ design rules under a new name.</description>
 <wire x1="6.460715625" y1="47.608715625" x2="7.5940625" y2="47.608715625" width="0.508" layer="1"/>
 <wire x1="6.576825" y1="45.714421875" x2="6.576825" y2="45.71460625" width="0.508" layer="1"/>
 <wire x1="6.576825" y1="45.71460625" x2="5.571715625" y2="46.719715625" width="0.508" layer="1"/>
-<wire x1="8.55621875" y1="35.799346875" x2="8.55621875" y2="35.179" width="0.508" layer="16"/>
-<via x="8.55621875" y="25.4" extent="1-16" drill="0.3048"/>
-<wire x1="8.55621875" y1="25.4" x2="8.55621875" y2="35.179" width="0.508" layer="16"/>
-<wire x1="8.55621875" y1="25.4" x2="8.55621875" y2="24.003" width="0.508" layer="1"/>
-<wire x1="10.273" y1="22.28621875" x2="8.55621875" y2="24.003" width="0.508" layer="1"/>
-<wire x1="10.273" y1="22.28621875" x2="10.273" y2="13.97" width="0.508" layer="1"/>
+<via x="9.57221875" y="20.193" extent="1-16" drill="0.3048"/>
+<wire x1="9.57221875" y1="20.193" x2="9.57221875" y2="33.02" width="0.508" layer="16"/>
+<wire x1="9.57221875" y1="33.702215625" x2="9.57221875" y2="34.29" width="0.508" layer="16"/>
+<wire x1="9.57221875" y1="34.29" x2="9.57221875" y2="34.78335" width="0.508" layer="16"/>
+<wire x1="9.57221875" y1="20.193" x2="9.57221875" y2="18.923" width="0.508" layer="1"/>
+<wire x1="10.273" y1="18.22221875" x2="9.57221875" y2="18.923" width="0.508" layer="1"/>
+<wire x1="10.273" y1="18.22221875" x2="10.273" y2="13.97" width="0.508" layer="1"/>
 <wire x1="14.367284375" y1="39.099715625" x2="11.125" y2="42.342" width="0.508" layer="16"/>
 <wire x1="5.571715625" y1="46.719715625" x2="5.571715625" y2="47.21143125" width="0.508" layer="1"/>
 <wire x1="5.571715625" y1="47.21143125" x2="5.969" y2="47.608715625" width="0.508" layer="1"/>
-<wire x1="6.96871875" y1="34.30628125" x2="8.048221875" y2="35.385784375" width="0.508" layer="16"/>
+<wire x1="6.96871875" y1="34.30628125" x2="7.92121875" y2="35.25878125" width="0.508" layer="16"/>
+<wire x1="7.92121875" y1="35.25878125" x2="8.048221875" y2="35.385784375" width="0.508" layer="16"/>
 <wire x1="8.048221875" y1="35.385784375" x2="8.96978125" y2="35.385784375" width="0.508" layer="16"/>
 <wire x1="6.96871875" y1="34.30628125" x2="7.66721875" y2="35.00478125" width="0.508" layer="16"/>
-<wire x1="7.66721875" y1="35.00478125" x2="9.350784375" y2="35.00478125" width="0.508" layer="16"/>
-<wire x1="8.55621875" y1="35.179" x2="8.86639375" y2="35.489175" width="0.508" layer="16"/>
 <contactref element="U1" pad="34"/>
 <contactref element="U1" pad="14"/>
 <contactref element="U1" pad="24"/>
@@ -1165,7 +1158,7 @@ design rules under a new name.</description>
 <wire x1="4.826" y1="32.1635625" x2="6.96871875" y2="34.30628125" width="0.254" layer="16"/>
 <wire x1="10.938284375" y1="33.29028125" x2="12.986565625" y2="31.242" width="0.254" layer="16"/>
 <wire x1="12.986565625" y1="31.242" x2="13.716" y2="31.242" width="0.254" layer="16"/>
-<via x="13.716" y="31.242" extent="1-16" drill="0.35"/>
+<via x="13.716" y="31.242" extent="1-16" drill="0.3048"/>
 <wire x1="13.716" y1="31.242" x2="12.98463125" y2="31.242" width="0.254" layer="1"/>
 <wire x1="11.8957875" y1="32.352634375" x2="11.8957875" y2="32.33084375" width="0.254" layer="1"/>
 <wire x1="12.98463125" y1="31.242" x2="11.8957875" y2="32.33084375" width="0.254" layer="1"/>
@@ -1175,6 +1168,14 @@ design rules under a new name.</description>
 <wire x1="3.202896875" y1="36.282159375" x2="2.674603125" y2="35.753865625" width="0.254" layer="1"/>
 <wire x1="1.412265625" y1="38.084734375" x2="1.397" y2="38.1" width="0.254" layer="1"/>
 <wire x1="1.412265625" y1="36.149740625" x2="1.412265625" y2="38.084734375" width="0.254" layer="1"/>
+<wire x1="8.55621875" y1="35.672346875" x2="8.55621875" y2="35.799346875" width="0.508" layer="16"/>
+<wire x1="8.55621875" y1="35.89378125" x2="8.55621875" y2="35.799346875" width="0.508" layer="16"/>
+<wire x1="8.96978125" y1="35.385784375" x2="10.112784375" y2="34.24278125" width="0.508" layer="16"/>
+<wire x1="10.112784375" y1="34.24278125" x2="10.938284375" y2="33.41728125" width="0.508" layer="16"/>
+<wire x1="7.92121875" y1="35.25878125" x2="8.6034375" y2="35.25878125" width="0.508" layer="16"/>
+<wire x1="8.6034375" y1="35.25878125" x2="9.57221875" y2="34.29" width="0.508" layer="16"/>
+<wire x1="9.57221875" y1="33.02" x2="9.57221875" y2="33.702215625" width="0.508" layer="16"/>
+<wire x1="9.57221875" y1="33.702215625" x2="10.112784375" y2="34.24278125" width="0.508" layer="16"/>
 </signal>
 <signal name="N$3">
 <contactref element="SW00" pad="2A"/>
@@ -1184,7 +1185,14 @@ design rules under a new name.</description>
 <contactref element="U1" pad="13"/>
 <contactref element="R1" pad="2"/>
 <wire x1="6.955" y1="12.402" x2="8.523" y2="13.97" width="0.254" layer="1"/>
-<wire x1="8.523" y1="13.97" x2="11.32105" y2="31.777896875" width="0" layer="19" extent="1-1"/>
+<wire x1="11.32105" y1="31.777896875" x2="12.446" y2="30.652946875" width="0.254" layer="1"/>
+<wire x1="12.446" y1="30.652946875" x2="12.446" y2="30.226" width="0.254" layer="1"/>
+<via x="12.446" y="30.226" extent="1-16" drill="0.3048"/>
+<wire x1="12.446" y1="30.226" x2="12.446" y2="21.082" width="0.254" layer="16"/>
+<wire x1="12.446" y1="21.082" x2="8.509" y2="17.145" width="0.254" layer="16"/>
+<via x="8.509" y="17.145" extent="1-16" drill="0.35"/>
+<wire x1="8.523" y1="13.97" x2="8.509" y2="13.984" width="0.254" layer="1"/>
+<wire x1="8.509" y1="17.145" x2="8.509" y2="13.984" width="0.254" layer="1"/>
 </signal>
 <signal name="UCAP">
 <contactref element="C8" pad="1"/>
@@ -1260,12 +1268,12 @@ design rules under a new name.</description>
 <wire x1="63.461" y1="29.347925" x2="63.461" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="63.461" y1="27.802075" x2="62.865" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="62.865" y1="27.206075" x2="62.865" y2="12.065" width="0.254" layer="16"/>
-<wire x1="18.542" y1="71.501" x2="20.701" y2="73.66" width="0.254" layer="1"/>
-<wire x1="20.701" y1="73.66" x2="60.96" y2="73.66" width="0.254" layer="1"/>
+<wire x1="18.542" y1="71.374" x2="20.828" y2="73.66" width="0.254" layer="1"/>
+<wire x1="20.828" y1="73.66" x2="60.96" y2="73.66" width="0.254" layer="1"/>
 <via x="60.96" y="73.66" extent="1-16" drill="0.3048"/>
 <wire x1="60.96" y1="73.66" x2="62.865" y2="71.755" width="0.254" layer="16"/>
 <wire x1="62.865" y1="71.755" x2="62.865" y2="69.215" width="0.254" layer="16"/>
-<wire x1="18.542" y1="48.26" x2="18.542" y2="71.501" width="0.254" layer="1"/>
+<wire x1="18.542" y1="48.26" x2="18.542" y2="71.374" width="0.254" layer="1"/>
 <contactref element="U1" pad="29"/>
 <wire x1="13.027296875" y1="42.71585" x2="13.027296875" y2="42.745296875" width="0.254" layer="1"/>
 <wire x1="13.027296875" y1="42.745296875" x2="18.542" y2="48.26" width="0.254" layer="1"/>
@@ -1322,9 +1330,9 @@ design rules under a new name.</description>
 <wire x1="25.361" y1="29.347925" x2="25.361" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="25.361" y1="27.802075" x2="24.765" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="24.765" y1="27.206075" x2="24.765" y2="12.065" width="0.254" layer="16"/>
-<wire x1="11.8957875" y1="43.8473625" x2="17.399" y2="49.350575" width="0.254" layer="1"/>
-<wire x1="17.399" y1="49.350575" x2="17.399" y2="72.644" width="0.254" layer="1"/>
-<wire x1="17.399" y1="72.644" x2="18.542" y2="73.787" width="0.254" layer="1"/>
+<wire x1="11.8957875" y1="43.8473625" x2="17.526" y2="49.477575" width="0.254" layer="1"/>
+<wire x1="17.526" y1="49.477575" x2="17.526" y2="72.771" width="0.254" layer="1"/>
+<wire x1="17.526" y1="72.771" x2="18.542" y2="73.787" width="0.254" layer="1"/>
 <via x="18.542" y="73.787" extent="1-16" drill="0.3048"/>
 <wire x1="18.542" y1="73.787" x2="23.114" y2="69.215" width="0.254" layer="16"/>
 <wire x1="23.114" y1="69.215" x2="24.765" y2="69.215" width="0.254" layer="16"/>
@@ -1413,8 +1421,8 @@ design rules under a new name.</description>
 </signal>
 <signal name="N$38">
 <wire x1="55.88" y1="58.42" x2="57.15" y2="59.69" width="0.254" layer="1"/>
-<wire x1="19.177" y1="47.752" x2="19.177" y2="57.023" width="0.254" layer="1"/>
-<wire x1="19.177" y1="57.023" x2="20.574" y2="58.42" width="0.254" layer="1"/>
+<wire x1="19.05" y1="47.625" x2="19.05" y2="56.896" width="0.254" layer="1"/>
+<wire x1="19.05" y1="56.896" x2="20.574" y2="58.42" width="0.254" layer="1"/>
 <contactref element="D10" pad="C"/>
 <contactref element="D11" pad="C"/>
 <contactref element="D12" pad="C"/>
@@ -1427,7 +1435,7 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="59.69" x2="38.1" y2="58.42" width="0.254" layer="1"/>
 <wire x1="20.574" y1="58.42" x2="38.1" y2="58.42" width="0.254" layer="1"/>
 <contactref element="U1" pad="28"/>
-<wire x1="13.584075" y1="42.159075" x2="19.177" y2="47.752" width="0.254" layer="1"/>
+<wire x1="13.584075" y1="42.159075" x2="19.05" y2="47.625" width="0.254" layer="1"/>
 </signal>
 <signal name="N$39">
 <contactref element="SW11" pad="MX2"/>
@@ -1509,23 +1517,15 @@ design rules under a new name.</description>
 <contactref element="C9" pad="2"/>
 <wire x1="12.17571875" y1="34.527715625" x2="12.17571875" y2="34.17928125" width="0.254" layer="16"/>
 <wire x1="4.33428125" y1="45.48228125" x2="4.33428125" y2="45.042165625" width="0.254" layer="1"/>
-<contactref element="Y1" pad="2"/>
-<contactref element="Y1" pad="4"/>
 <contactref element="C1" pad="1"/>
 <contactref element="C2" pad="1"/>
 <contactref element="SW00" pad="1A"/>
 <contactref element="SW00" pad="1B"/>
 <contactref element="R2" pad="1"/>
-<wire x1="12.693" y1="28.484" x2="10.718" y2="28.484" width="0.254" layer="1"/>
-<wire x1="10.668" y1="28.434" x2="10.718" y2="28.484" width="0.254" layer="1"/>
-<wire x1="13.143" y1="28.484" x2="12.693" y2="28.484" width="0.254" layer="1"/>
-<wire x1="14.993" y1="26.634" x2="15.043" y2="26.684" width="0.254" layer="1"/>
+<wire x1="5.08" y1="27.545" x2="5.13" y2="27.595" width="0.254" layer="1"/>
 <wire x1="13.335" y1="63.008" x2="13.335" y2="61.341" width="0.254" layer="1"/>
 <via x="13.335" y="61.341" extent="1-16" drill="0.3048"/>
-<wire x1="17.018" y1="26.684" x2="17.018" y2="24.384" width="0.254" layer="1"/>
-<via x="17.018" y="24.384" extent="1-16" drill="0.3048"/>
-<wire x1="3.556" y1="29.605" x2="3.556" y2="27.94" width="0.254" layer="1"/>
-<via x="3.556" y="27.94" extent="1-16" drill="0.3048"/>
+<wire x1="13.97" y1="25.795" x2="13.97" y2="23.495" width="0.254" layer="1"/>
 <wire x1="7.925" y1="67.55" x2="7.925" y2="65.202" width="0.508" layer="1"/>
 <wire x1="7.925" y1="65.202" x2="7.874" y2="65.151" width="0.508" layer="1"/>
 <polygon width="0.254" layer="1">
@@ -1545,6 +1545,8 @@ design rules under a new name.</description>
 <contactref element="U1" pad="35"/>
 <contactref element="U1" pad="43"/>
 <contactref element="U1" pad="5"/>
+<contactref element="Y1" pad="4"/>
+<contactref element="Y1" pad="2"/>
 </signal>
 </signals>
 <mfgpreviewcolors>

--- a/PCB/MacroPad.brd
+++ b/PCB/MacroPad.brd
@@ -260,63 +260,6 @@
 <library name="Controller">
 <description>Footprints used for the controller and other supporting hardware</description>
 <packages>
-<package name="QFN-44">
-<description>QFN44 footprint</description>
-<wire x1="-4.135" y1="-4.135" x2="-4.135" y2="3.34443125" width="0.127" layer="21"/>
-<wire x1="-4.135" y1="3.34443125" x2="-3.34443125" y2="4.135" width="0.127" layer="21"/>
-<wire x1="-3.34443125" y1="4.135" x2="4.135" y2="4.135" width="0.127" layer="21"/>
-<wire x1="4.135" y1="4.135" x2="4.135" y2="-4.135" width="0.127" layer="21"/>
-<wire x1="4.135" y1="-4.135" x2="-4.135" y2="-4.135" width="0.127" layer="21"/>
-<smd name="TAB" x="0" y="0" dx="5.08" dy="5.08" layer="1" roundness="10"/>
-<smd name="1" x="-3.35" y="2.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="2" x="-3.35" y="2" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="3" x="-3.35" y="1.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="4" x="-3.35" y="1" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="5" x="-3.35" y="0.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="6" x="-3.35" y="0" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="7" x="-3.35" y="-0.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="8" x="-3.35" y="-1" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="9" x="-3.35" y="-1.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="10" x="-3.35" y="-2" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="11" x="-3.35" y="-2.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="12" x="-2.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="13" x="-2" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="14" x="-1.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="15" x="-1" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="16" x="-0.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="17" x="0" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="18" x="0.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="19" x="1" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="20" x="1.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="21" x="2" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="22" x="2.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="23" x="3.35" y="-2.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="24" x="3.35" y="-2" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="25" x="3.35" y="-1.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="26" x="3.35" y="-1" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="27" x="3.35" y="-0.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="28" x="3.35" y="0" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="29" x="3.35" y="0.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="30" x="3.35" y="1" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="31" x="3.35" y="1.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="32" x="3.35" y="2" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="33" x="3.35" y="2.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="34" x="2.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="35" x="2" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="36" x="1.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="37" x="1" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="38" x="0.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="39" x="0" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="40" x="-0.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="41" x="-1" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="42" x="-1.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="43" x="-2" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="44" x="-2.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<circle x="-4.445" y="4.445" radius="0.381" width="0" layer="21"/>
-<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="39"/>
-<text x="-1.905" y="4.445" size="0.889" layer="25" ratio="11">&gt;NAME</text>
-<text x="-2.54" y="-5.08" size="0.889" layer="27" ratio="11">&gt;VALUE</text>
-</package>
 <package name="UX60-MB-5S8">
 <description>HiRose UX60-MB-5S8 Mini-USB Female</description>
 <smd name="VCC" x="8.65" y="1.6" dx="2" dy="0.5" layer="1"/>
@@ -443,6 +386,247 @@
 </packageinstances>
 </package3d>
 </packages3d>
+</library>
+<library name="ATMEGA32U4-AUR">
+<packages>
+<package name="QFP80P1200X1200X120-44N">
+<wire x1="-4.572" y1="5.0546" x2="-5.0546" y2="5.0546" width="0.1524" layer="21"/>
+<wire x1="5.0546" y1="4.572" x2="5.0546" y2="5.0546" width="0.1524" layer="21"/>
+<wire x1="4.572" y1="-5.0546" x2="5.0546" y2="-5.0546" width="0.1524" layer="21"/>
+<wire x1="-5.0546" y1="-5.0546" x2="-4.572" y2="-5.0546" width="0.1524" layer="21"/>
+<wire x1="5.0546" y1="-5.0546" x2="5.0546" y2="-4.572" width="0.1524" layer="21"/>
+<wire x1="5.0546" y1="5.0546" x2="4.572" y2="5.0546" width="0.1524" layer="21"/>
+<wire x1="-5.0546" y1="5.0546" x2="-5.0546" y2="4.572" width="0.1524" layer="21"/>
+<wire x1="-5.0546" y1="-4.572" x2="-5.0546" y2="-5.0546" width="0.1524" layer="21"/>
+<wire x1="3.7846" y1="5.0546" x2="4.2164" y2="5.0546" width="0" layer="51"/>
+<wire x1="4.2164" y1="5.0546" x2="4.2164" y2="6.1214" width="0" layer="51"/>
+<wire x1="4.2164" y1="6.1214" x2="3.7846" y2="6.1214" width="0" layer="51"/>
+<wire x1="3.7846" y1="6.1214" x2="3.7846" y2="5.0546" width="0" layer="51"/>
+<wire x1="2.9718" y1="5.0546" x2="3.429" y2="5.0546" width="0" layer="51"/>
+<wire x1="3.429" y1="5.0546" x2="3.429" y2="6.1214" width="0" layer="51"/>
+<wire x1="3.429" y1="6.1214" x2="2.9718" y2="6.1214" width="0" layer="51"/>
+<wire x1="2.9718" y1="6.1214" x2="2.9718" y2="5.0546" width="0" layer="51"/>
+<wire x1="2.1844" y1="5.0546" x2="2.6162" y2="5.0546" width="0" layer="51"/>
+<wire x1="2.6162" y1="5.0546" x2="2.6162" y2="6.1214" width="0" layer="51"/>
+<wire x1="2.6162" y1="6.1214" x2="2.1844" y2="6.1214" width="0" layer="51"/>
+<wire x1="2.1844" y1="6.1214" x2="2.1844" y2="5.0546" width="0" layer="51"/>
+<wire x1="1.3716" y1="5.0546" x2="1.8288" y2="5.0546" width="0" layer="51"/>
+<wire x1="1.8288" y1="5.0546" x2="1.8288" y2="6.1214" width="0" layer="51"/>
+<wire x1="1.8288" y1="6.1214" x2="1.3716" y2="6.1214" width="0" layer="51"/>
+<wire x1="1.3716" y1="6.1214" x2="1.3716" y2="5.0546" width="0" layer="51"/>
+<wire x1="0.5842" y1="5.0546" x2="1.016" y2="5.0546" width="0" layer="51"/>
+<wire x1="1.016" y1="5.0546" x2="1.016" y2="6.1214" width="0" layer="51"/>
+<wire x1="1.016" y1="6.1214" x2="0.5842" y2="6.1214" width="0" layer="51"/>
+<wire x1="0.5842" y1="6.1214" x2="0.5842" y2="5.0546" width="0" layer="51"/>
+<wire x1="-0.2286" y1="5.0546" x2="0.2286" y2="5.0546" width="0" layer="51"/>
+<wire x1="0.2286" y1="5.0546" x2="0.2286" y2="6.1214" width="0" layer="51"/>
+<wire x1="0.2286" y1="6.1214" x2="-0.2286" y2="6.1214" width="0" layer="51"/>
+<wire x1="-0.2286" y1="6.1214" x2="-0.2286" y2="5.0546" width="0" layer="51"/>
+<wire x1="-1.016" y1="5.0546" x2="-0.5842" y2="5.0546" width="0" layer="51"/>
+<wire x1="-0.5842" y1="5.0546" x2="-0.5842" y2="6.1214" width="0" layer="51"/>
+<wire x1="-0.5842" y1="6.1214" x2="-1.016" y2="6.1214" width="0" layer="51"/>
+<wire x1="-1.016" y1="6.1214" x2="-1.016" y2="5.0546" width="0" layer="51"/>
+<wire x1="-1.8288" y1="5.0546" x2="-1.3716" y2="5.0546" width="0" layer="51"/>
+<wire x1="-1.3716" y1="5.0546" x2="-1.3716" y2="6.1214" width="0" layer="51"/>
+<wire x1="-1.3716" y1="6.1214" x2="-1.8288" y2="6.1214" width="0" layer="51"/>
+<wire x1="-1.8288" y1="6.1214" x2="-1.8288" y2="5.0546" width="0" layer="51"/>
+<wire x1="-2.6162" y1="5.0546" x2="-2.1844" y2="5.0546" width="0" layer="51"/>
+<wire x1="-2.1844" y1="5.0546" x2="-2.1844" y2="6.1214" width="0" layer="51"/>
+<wire x1="-2.1844" y1="6.1214" x2="-2.6162" y2="6.1214" width="0" layer="51"/>
+<wire x1="-2.6162" y1="6.1214" x2="-2.6162" y2="5.0546" width="0" layer="51"/>
+<wire x1="-3.429" y1="5.0546" x2="-2.9718" y2="5.0546" width="0" layer="51"/>
+<wire x1="-2.9718" y1="5.0546" x2="-2.9718" y2="6.1214" width="0" layer="51"/>
+<wire x1="-2.9718" y1="6.1214" x2="-3.429" y2="6.1214" width="0" layer="51"/>
+<wire x1="-3.429" y1="6.1214" x2="-3.429" y2="5.0546" width="0" layer="51"/>
+<wire x1="-4.2164" y1="5.0546" x2="-3.7846" y2="5.0546" width="0" layer="51"/>
+<wire x1="-3.7846" y1="5.0546" x2="-3.7846" y2="6.1214" width="0" layer="51"/>
+<wire x1="-3.7846" y1="6.1214" x2="-4.2164" y2="6.1214" width="0" layer="51"/>
+<wire x1="-4.2164" y1="6.1214" x2="-4.2164" y2="5.0546" width="0" layer="51"/>
+<wire x1="-5.0546" y1="3.7846" x2="-5.0546" y2="4.2164" width="0" layer="51"/>
+<wire x1="-5.0546" y1="4.2164" x2="-6.1214" y2="4.2164" width="0" layer="51"/>
+<wire x1="-6.1214" y1="4.2164" x2="-6.1214" y2="3.7846" width="0" layer="51"/>
+<wire x1="-6.1214" y1="3.7846" x2="-5.0546" y2="3.7846" width="0" layer="51"/>
+<wire x1="-5.0546" y1="2.9718" x2="-5.0546" y2="3.429" width="0" layer="51"/>
+<wire x1="-5.0546" y1="3.429" x2="-6.1214" y2="3.429" width="0" layer="51"/>
+<wire x1="-6.1214" y1="3.429" x2="-6.1214" y2="2.9718" width="0" layer="51"/>
+<wire x1="-6.1214" y1="2.9718" x2="-5.0546" y2="2.9718" width="0" layer="51"/>
+<wire x1="-5.0546" y1="2.1844" x2="-5.0546" y2="2.6162" width="0" layer="51"/>
+<wire x1="-5.0546" y1="2.6162" x2="-6.1214" y2="2.6162" width="0" layer="51"/>
+<wire x1="-6.1214" y1="2.6162" x2="-6.1214" y2="2.1844" width="0" layer="51"/>
+<wire x1="-6.1214" y1="2.1844" x2="-5.0546" y2="2.1844" width="0" layer="51"/>
+<wire x1="-5.0546" y1="1.3716" x2="-5.0546" y2="1.8288" width="0" layer="51"/>
+<wire x1="-5.0546" y1="1.8288" x2="-6.1214" y2="1.8288" width="0" layer="51"/>
+<wire x1="-6.1214" y1="1.8288" x2="-6.1214" y2="1.3716" width="0" layer="51"/>
+<wire x1="-6.1214" y1="1.3716" x2="-5.0546" y2="1.3716" width="0" layer="51"/>
+<wire x1="-5.0546" y1="0.5842" x2="-5.0546" y2="1.016" width="0" layer="51"/>
+<wire x1="-5.0546" y1="1.016" x2="-6.1214" y2="1.016" width="0" layer="51"/>
+<wire x1="-6.1214" y1="1.016" x2="-6.1214" y2="0.5842" width="0" layer="51"/>
+<wire x1="-6.1214" y1="0.5842" x2="-5.0546" y2="0.5842" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-0.2286" x2="-5.0546" y2="0.2286" width="0" layer="51"/>
+<wire x1="-5.0546" y1="0.2286" x2="-6.1214" y2="0.2286" width="0" layer="51"/>
+<wire x1="-6.1214" y1="0.2286" x2="-6.1214" y2="-0.2286" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-0.2286" x2="-5.0546" y2="-0.2286" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-1.016" x2="-5.0546" y2="-0.5842" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-0.5842" x2="-6.1214" y2="-0.5842" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-0.5842" x2="-6.1214" y2="-1.016" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-1.016" x2="-5.0546" y2="-1.016" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-1.8288" x2="-5.0546" y2="-1.3716" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-1.3716" x2="-6.1214" y2="-1.3716" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-1.3716" x2="-6.1214" y2="-1.8288" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-1.8288" x2="-5.0546" y2="-1.8288" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-2.6162" x2="-5.0546" y2="-2.1844" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-2.1844" x2="-6.1214" y2="-2.1844" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-2.1844" x2="-6.1214" y2="-2.6162" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-2.6162" x2="-5.0546" y2="-2.6162" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-3.429" x2="-5.0546" y2="-2.9718" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-2.9718" x2="-6.1214" y2="-2.9718" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-2.9718" x2="-6.1214" y2="-3.429" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-3.429" x2="-5.0546" y2="-3.429" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-4.2164" x2="-5.0546" y2="-3.7846" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-3.7846" x2="-6.1214" y2="-3.7846" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-3.7846" x2="-6.1214" y2="-4.2164" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-4.2164" x2="-5.0546" y2="-4.2164" width="0" layer="51"/>
+<wire x1="-3.7846" y1="-5.0546" x2="-4.2164" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-4.2164" y1="-5.0546" x2="-4.2164" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-4.2164" y1="-6.1214" x2="-3.7846" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-3.7846" y1="-6.1214" x2="-3.7846" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-2.9718" y1="-5.0546" x2="-3.429" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-3.429" y1="-5.0546" x2="-3.429" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-3.429" y1="-6.1214" x2="-2.9718" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-2.9718" y1="-6.1214" x2="-2.9718" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-2.1844" y1="-5.0546" x2="-2.6162" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-2.6162" y1="-5.0546" x2="-2.6162" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-2.6162" y1="-6.1214" x2="-2.1844" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-2.1844" y1="-6.1214" x2="-2.1844" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-1.3716" y1="-5.0546" x2="-1.8288" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-1.8288" y1="-5.0546" x2="-1.8288" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-1.8288" y1="-6.1214" x2="-1.3716" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-1.3716" y1="-6.1214" x2="-1.3716" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-0.5842" y1="-5.0546" x2="-1.016" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-1.016" y1="-5.0546" x2="-1.016" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-1.016" y1="-6.1214" x2="-0.5842" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-0.5842" y1="-6.1214" x2="-0.5842" y2="-5.0546" width="0" layer="51"/>
+<wire x1="0.2286" y1="-5.0546" x2="-0.2286" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-0.2286" y1="-5.0546" x2="-0.2286" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-0.2286" y1="-6.1214" x2="0.2286" y2="-6.1214" width="0" layer="51"/>
+<wire x1="0.2286" y1="-6.1214" x2="0.2286" y2="-5.0546" width="0" layer="51"/>
+<wire x1="1.016" y1="-5.0546" x2="0.5842" y2="-5.0546" width="0" layer="51"/>
+<wire x1="0.5842" y1="-5.0546" x2="0.5842" y2="-6.1214" width="0" layer="51"/>
+<wire x1="0.5842" y1="-6.1214" x2="1.016" y2="-6.1214" width="0" layer="51"/>
+<wire x1="1.016" y1="-6.1214" x2="1.016" y2="-5.0546" width="0" layer="51"/>
+<wire x1="1.8288" y1="-5.0546" x2="1.3716" y2="-5.0546" width="0" layer="51"/>
+<wire x1="1.3716" y1="-5.0546" x2="1.3716" y2="-6.1214" width="0" layer="51"/>
+<wire x1="1.3716" y1="-6.1214" x2="1.8288" y2="-6.1214" width="0" layer="51"/>
+<wire x1="1.8288" y1="-6.1214" x2="1.8288" y2="-5.0546" width="0" layer="51"/>
+<wire x1="2.6162" y1="-5.0546" x2="2.1844" y2="-5.0546" width="0" layer="51"/>
+<wire x1="2.1844" y1="-5.0546" x2="2.1844" y2="-6.1214" width="0" layer="51"/>
+<wire x1="2.1844" y1="-6.1214" x2="2.6162" y2="-6.1214" width="0" layer="51"/>
+<wire x1="2.6162" y1="-6.1214" x2="2.6162" y2="-5.0546" width="0" layer="51"/>
+<wire x1="3.429" y1="-5.0546" x2="2.9718" y2="-5.0546" width="0" layer="51"/>
+<wire x1="2.9718" y1="-5.0546" x2="2.9718" y2="-6.1214" width="0" layer="51"/>
+<wire x1="2.9718" y1="-6.1214" x2="3.429" y2="-6.1214" width="0" layer="51"/>
+<wire x1="3.429" y1="-6.1214" x2="3.429" y2="-5.0546" width="0" layer="51"/>
+<wire x1="4.2164" y1="-5.0546" x2="3.7846" y2="-5.0546" width="0" layer="51"/>
+<wire x1="3.7846" y1="-5.0546" x2="3.7846" y2="-6.1214" width="0" layer="51"/>
+<wire x1="3.7846" y1="-6.1214" x2="4.2164" y2="-6.1214" width="0" layer="51"/>
+<wire x1="4.2164" y1="-6.1214" x2="4.2164" y2="-5.0546" width="0" layer="51"/>
+<wire x1="5.0546" y1="-3.7846" x2="5.0546" y2="-4.2164" width="0" layer="51"/>
+<wire x1="5.0546" y1="-4.2164" x2="6.1214" y2="-4.2164" width="0" layer="51"/>
+<wire x1="6.1214" y1="-4.2164" x2="6.1214" y2="-3.7846" width="0" layer="51"/>
+<wire x1="6.1214" y1="-3.7846" x2="5.0546" y2="-3.7846" width="0" layer="51"/>
+<wire x1="5.0546" y1="-2.9718" x2="5.0546" y2="-3.429" width="0" layer="51"/>
+<wire x1="5.0546" y1="-3.429" x2="6.1214" y2="-3.429" width="0" layer="51"/>
+<wire x1="6.1214" y1="-3.429" x2="6.1214" y2="-2.9718" width="0" layer="51"/>
+<wire x1="6.1214" y1="-2.9718" x2="5.0546" y2="-2.9718" width="0" layer="51"/>
+<wire x1="5.0546" y1="-2.1844" x2="5.0546" y2="-2.6162" width="0" layer="51"/>
+<wire x1="5.0546" y1="-2.6162" x2="6.1214" y2="-2.6162" width="0" layer="51"/>
+<wire x1="6.1214" y1="-2.6162" x2="6.1214" y2="-2.1844" width="0" layer="51"/>
+<wire x1="6.1214" y1="-2.1844" x2="5.0546" y2="-2.1844" width="0" layer="51"/>
+<wire x1="5.0546" y1="-1.3716" x2="5.0546" y2="-1.8288" width="0" layer="51"/>
+<wire x1="5.0546" y1="-1.8288" x2="6.1214" y2="-1.8288" width="0" layer="51"/>
+<wire x1="6.1214" y1="-1.8288" x2="6.1214" y2="-1.3716" width="0" layer="51"/>
+<wire x1="6.1214" y1="-1.3716" x2="5.0546" y2="-1.3716" width="0" layer="51"/>
+<wire x1="5.0546" y1="-0.5842" x2="5.0546" y2="-1.016" width="0" layer="51"/>
+<wire x1="5.0546" y1="-1.016" x2="6.1214" y2="-1.016" width="0" layer="51"/>
+<wire x1="6.1214" y1="-1.016" x2="6.1214" y2="-0.5842" width="0" layer="51"/>
+<wire x1="6.1214" y1="-0.5842" x2="5.0546" y2="-0.5842" width="0" layer="51"/>
+<wire x1="5.0546" y1="0.2286" x2="5.0546" y2="-0.2286" width="0" layer="51"/>
+<wire x1="5.0546" y1="-0.2286" x2="6.1214" y2="-0.2286" width="0" layer="51"/>
+<wire x1="6.1214" y1="-0.2286" x2="6.1214" y2="0.2286" width="0" layer="51"/>
+<wire x1="6.1214" y1="0.2286" x2="5.0546" y2="0.2286" width="0" layer="51"/>
+<wire x1="5.0546" y1="1.016" x2="5.0546" y2="0.5842" width="0" layer="51"/>
+<wire x1="5.0546" y1="0.5842" x2="6.1214" y2="0.5842" width="0" layer="51"/>
+<wire x1="6.1214" y1="0.5842" x2="6.1214" y2="1.016" width="0" layer="51"/>
+<wire x1="6.1214" y1="1.016" x2="5.0546" y2="1.016" width="0" layer="51"/>
+<wire x1="5.0546" y1="1.8288" x2="5.0546" y2="1.3716" width="0" layer="51"/>
+<wire x1="5.0546" y1="1.3716" x2="6.1214" y2="1.3716" width="0" layer="51"/>
+<wire x1="6.1214" y1="1.3716" x2="6.1214" y2="1.8288" width="0" layer="51"/>
+<wire x1="6.1214" y1="1.8288" x2="5.0546" y2="1.8288" width="0" layer="51"/>
+<wire x1="5.0546" y1="2.6162" x2="5.0546" y2="2.1844" width="0" layer="51"/>
+<wire x1="5.0546" y1="2.1844" x2="6.1214" y2="2.1844" width="0" layer="51"/>
+<wire x1="6.1214" y1="2.1844" x2="6.1214" y2="2.6162" width="0" layer="51"/>
+<wire x1="6.1214" y1="2.6162" x2="5.0546" y2="2.6162" width="0" layer="51"/>
+<wire x1="5.0546" y1="3.429" x2="5.0546" y2="2.9718" width="0" layer="51"/>
+<wire x1="5.0546" y1="2.9718" x2="6.1214" y2="2.9718" width="0" layer="51"/>
+<wire x1="6.1214" y1="2.9718" x2="6.1214" y2="3.429" width="0" layer="51"/>
+<wire x1="6.1214" y1="3.429" x2="5.0546" y2="3.429" width="0" layer="51"/>
+<wire x1="5.0546" y1="4.2164" x2="5.0546" y2="3.7846" width="0" layer="51"/>
+<wire x1="5.0546" y1="3.7846" x2="6.1214" y2="3.7846" width="0" layer="51"/>
+<wire x1="6.1214" y1="3.7846" x2="6.1214" y2="4.2164" width="0" layer="51"/>
+<wire x1="6.1214" y1="4.2164" x2="5.0546" y2="4.2164" width="0" layer="51"/>
+<wire x1="-5.0546" y1="3.7846" x2="-3.7846" y2="5.0546" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-5.0546" x2="5.0546" y2="-5.0546" width="0" layer="51"/>
+<wire x1="5.0546" y1="-5.0546" x2="5.0546" y2="5.0546" width="0" layer="51"/>
+<wire x1="5.0546" y1="5.0546" x2="-5.0546" y2="5.0546" width="0" layer="51"/>
+<wire x1="-5.0546" y1="5.0546" x2="-5.0546" y2="-5.0546" width="0" layer="51"/>
+<text x="-4.17045" y="-10.0955" size="2.08521875" layer="25" ratio="10" rot="SR0">&gt;NAME</text>
+<text x="-3.46611875" y="10.118" size="2.089859375" layer="27" ratio="10" rot="SR0">&gt;VALUE</text>
+<smd name="1" x="-5.7404" y="3.9878" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="2" x="-5.7404" y="3.2004" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="3" x="-5.7404" y="2.3876" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="4" x="-5.7404" y="1.6002" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="5" x="-5.7404" y="0.7874" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="6" x="-5.7404" y="0" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="7" x="-5.7404" y="-0.7874" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="8" x="-5.7404" y="-1.6002" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="9" x="-5.7404" y="-2.3876" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="10" x="-5.7404" y="-3.2004" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="11" x="-5.7404" y="-3.9878" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="12" x="-3.9878" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="13" x="-3.2004" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="14" x="-2.3876" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="15" x="-1.6002" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="16" x="-0.7874" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="17" x="0" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="18" x="0.7874" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="19" x="1.6002" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="20" x="2.3876" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="21" x="3.2004" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="22" x="3.9878" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="23" x="5.7404" y="-3.9878" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="24" x="5.7404" y="-3.2004" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="25" x="5.7404" y="-2.3876" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="26" x="5.7404" y="-1.6002" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="27" x="5.7404" y="-0.7874" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="28" x="5.7404" y="0" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="29" x="5.7404" y="0.7874" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="30" x="5.7404" y="1.6002" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="31" x="5.7404" y="2.3876" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="32" x="5.7404" y="3.2004" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="33" x="5.7404" y="3.9878" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="34" x="3.9878" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="35" x="3.2004" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="36" x="2.3876" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="37" x="1.6002" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="38" x="0.7874" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="39" x="0" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="40" x="-0.7874" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="41" x="-1.6002" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="42" x="-2.3876" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="43" x="-3.2004" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="44" x="-3.9878" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+</package>
+</packages>
 </library>
 </libraries>
 <attributes>
@@ -794,11 +978,6 @@ design rules under a new name.</description>
 <attribute name="NAME" x="28.575" y="63.875" size="1" layer="21" font="vector" ratio="13" align="center"/>
 <attribute name="OC_NEWARK" value="unknown" x="28.575" y="66.675" size="1.778" layer="27" display="off"/>
 </element>
-<element name="U$1" library="Controller" package="QFN-44" value="ATMEGA32U4-QFN44" x="9.525" y="38.1" smashed="yes" rot="R44.6">
-<attribute name="MF" value="" x="9.525" y="38.1" size="1.778" layer="27" rot="R44.6" display="off"/>
-<attribute name="MPN" value="" x="9.525" y="38.1" size="1.778" layer="27" rot="R44.6" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="9.525" y="38.1" size="1.778" layer="27" rot="R44.6" display="off"/>
-</element>
 <element name="USB1" library="Controller" package="UX60-MB-5S8" value="" x="9.525" y="76.2" smashed="yes" rot="R270">
 <attribute name="MF" value="" x="9.525" y="76.2" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="MPN" value="" x="9.525" y="76.2" size="1.778" layer="27" rot="R270" display="off"/>
@@ -866,13 +1045,21 @@ design rules under a new name.</description>
 <attribute name="NAME" x="40.64" y="69.215" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="39.116" y="68.707" size="0.6096" layer="21" rot="R270"/>
 </element>
+<element name="U1" library="ATMEGA32U4-AUR" package="QFP80P1200X1200X120-44N" value="ATMEGA32U4-AUR" x="-10.16" y="10.16" smashed="yes">
+<attribute name="AVAILABILITY" value="Unavailable" x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
+<attribute name="DESCRIPTION" value=" ATmega Series 16 MHz 32 KB Flash 2.5 KB SRAM 8-Bit Microcontroller - TQFP-44 " x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
+<attribute name="MF" value="Microchip" x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
+<attribute name="MP" value="ATMEGA32U4-AUR" x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
+<attribute name="NAME" x="-14.33045" y="0.0645" size="2.08521875" layer="25" ratio="10" rot="SR0"/>
+<attribute name="PACKAGE" value="TQFP-44 Microchip" x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
+<attribute name="PRICE" value="None" x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" x="-13.62611875" y="20.278" size="2.089859375" layer="27" ratio="10" rot="SR0"/>
+</element>
 </elements>
 <signals>
 <signal name="N$1">
-<contactref element="U$1" pad="16"/>
 <contactref element="Y1" pad="3"/>
 <contactref element="C2" pad="2"/>
-<wire x1="11.521196875" y1="35.363634375" x2="12.31823125" y2="34.5666" width="0.254" layer="1"/>
 <wire x1="12.31823125" y1="34.5666" x2="12.8453875" y2="34.5666" width="0.254" layer="1"/>
 <wire x1="12.8453875" y1="34.5666" x2="13.716" y2="33.6959875" width="0.254" layer="1"/>
 <wire x1="13.716" y1="33.6959875" x2="13.716" y2="33.02" width="0.254" layer="1"/>
@@ -885,19 +1072,21 @@ design rules under a new name.</description>
 <wire x1="10.541" y1="27.53" x2="10.541" y2="25.4" width="0.254" layer="1"/>
 <wire x1="8.636" y1="27.7" x2="10.611" y2="27.7" width="0.254" layer="1"/>
 <wire x1="10.611" y1="27.7" x2="10.661" y2="27.65" width="0.254" layer="1"/>
+<contactref element="U1" pad="16"/>
+<wire x1="-10.9474" y1="4.4196" x2="10.541" y2="25.4" width="0" layer="19" extent="1-16"/>
 </signal>
 <signal name="N$2">
 <contactref element="Y1" pad="1"/>
-<contactref element="U$1" pad="17"/>
 <contactref element="C1" pad="2"/>
 <wire x1="12.961" y1="29.5" x2="14.936" y2="29.5" width="0.254" layer="1"/>
 <wire x1="14.936" y1="29.5" x2="14.986" y2="29.45" width="0.254" layer="1"/>
-<wire x1="11.8772125" y1="35.7147125" x2="12.618925" y2="34.973" width="0.254" layer="1"/>
 <wire x1="12.618925" y1="34.973" x2="13.013725" y2="34.973" width="0.254" layer="1"/>
 <wire x1="12.961" y1="31.6902625" x2="12.961" y2="29.5" width="0.254" layer="1"/>
 <wire x1="13.013725" y1="34.973" x2="14.1224" y2="33.864325" width="0.254" layer="1"/>
 <wire x1="14.1224" y1="33.864325" x2="14.1224" y2="32.8516625" width="0.254" layer="1"/>
 <wire x1="14.1224" y1="32.8516625" x2="12.961" y2="31.6902625" width="0.254" layer="1"/>
+<contactref element="U1" pad="17"/>
+<wire x1="-10.16" y1="4.4196" x2="12.961" y2="29.5" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="VCC">
 <contactref element="C3" pad="1"/>
@@ -907,30 +1096,18 @@ design rules under a new name.</description>
 <contactref element="C7" pad="1"/>
 <contactref element="R1" pad="1"/>
 <contactref element="USB1" pad="VCC"/>
-<contactref element="U$1" pad="34"/>
-<contactref element="U$1" pad="14"/>
-<contactref element="U$1" pad="24"/>
-<contactref element="U$1" pad="44"/>
-<contactref element="U$1" pad="7"/>
-<contactref element="U$1" pad="2"/>
-<wire x1="13.314590625" y1="39.028159375" x2="14.141834375" y2="39.855403125" width="0.254" layer="1"/>
 <wire x1="15.253734375" y1="39.855403125" x2="15.761734375" y2="39.347403125" width="0.254" layer="1"/>
 <wire x1="15.253734375" y1="39.855403125" x2="14.141834375" y2="39.855403125" width="0.254" layer="1"/>
 <via x="15.761734375" y="39.347403125" extent="1-16" drill="0.3048"/>
 <wire x1="15.761734375" y1="39.347403125" x2="15.253734375" y2="39.855403125" width="0.254" layer="16"/>
 <wire x1="15.253734375" y1="39.855403125" x2="13.852971875" y2="39.855403125" width="0.254" layer="16"/>
 <wire x1="13.852971875" y1="39.855403125" x2="13.097284375" y2="39.099715625" width="0.254" layer="16"/>
-<wire x1="10.809171875" y1="34.66148125" x2="12.323653125" y2="33.147" width="0.254" layer="1"/>
 <wire x1="12.323653125" y1="33.147" x2="12.446" y2="33.147" width="0.254" layer="1"/>
 <via x="12.446" y="33.147" extent="1-16" drill="0.3048"/>
-<wire x1="7.4907875" y1="35.391771875" x2="6.096" y2="33.996984375" width="0.254" layer="1"/>
 <wire x1="6.096" y1="33.996984375" x2="6.096" y2="33.782" width="0.254" layer="1"/>
 <via x="6.096" y="33.782" extent="1-16" drill="0.3048"/>
 <wire x1="7.60371875" y1="34.94128125" x2="6.27021875" y2="33.60778125" width="0.254" layer="16"/>
 <wire x1="6.096" y1="33.782" x2="6.27021875" y2="33.60778125" width="0.254" layer="16"/>
-<wire x1="5.392721875" y1="38.729903125" x2="5.133625" y2="38.989" width="0.254" layer="1"/>
-<wire x1="5.08" y1="38.989" x2="5.133625" y2="38.989" width="0.254" layer="1"/>
-<wire x1="5.392721875" y1="38.729903125" x2="3.990625" y2="40.132" width="0.254" layer="1"/>
 <wire x1="3.990625" y1="40.132" x2="3.937" y2="40.132" width="0.254" layer="1"/>
 <via x="3.937" y="40.132" extent="1-16" drill="0.3048"/>
 <wire x1="3.937" y1="40.132" x2="3.937" y2="39.751" width="0.254" layer="16"/>
@@ -938,7 +1115,6 @@ design rules under a new name.</description>
 <wire x1="4.969284375" y1="38.718715625" x2="4.969284375" y2="38.24328125" width="0.254" layer="16"/>
 <wire x1="11.125" y1="67.55" x2="11.125" y2="46.101" width="0.508" layer="1"/>
 <contactref element="C9" pad="1"/>
-<wire x1="8.95285" y1="42.24066875" x2="8.481825" y2="42.71169375" width="0.254" layer="1"/>
 <wire x1="8.481825" y1="43.682421875" x2="8.100825" y2="44.063421875" width="0.254" layer="1"/>
 <wire x1="8.481825" y1="43.682421875" x2="8.481825" y2="42.71169375" width="0.254" layer="1"/>
 <wire x1="11.125" y1="47.117" x2="10.579" y2="46.571" width="0.508" layer="1"/>
@@ -961,12 +1137,6 @@ design rules under a new name.</description>
 <wire x1="6.35" y1="45.830715625" x2="7.857715625" y2="45.830715625" width="0.508" layer="1"/>
 <wire x1="7.095715625" y1="45.068715625" x2="8.100825" y2="44.06360625" width="0.508" layer="1"/>
 <wire x1="8.100825" y1="44.06360625" x2="8.100825" y2="44.063421875" width="0.508" layer="1"/>
-<wire x1="5.73540625" y1="37.1718375" x2="5.73540625" y2="37.14399375" width="0.254" layer="1"/>
-<wire x1="5.73540625" y1="37.14399375" x2="5.26395" y2="36.679078125" width="0.254" layer="1"/>
-<wire x1="5.26395" y1="36.679078125" x2="4.743896875" y2="36.682703125" width="0.254" layer="1"/>
-<wire x1="4.743896875" y1="36.682703125" x2="4.3511" y2="37.081028125" width="0.254" layer="1"/>
-<wire x1="4.3511" y1="37.081028125" x2="4.3511" y2="38.2601" width="0.254" layer="1"/>
-<wire x1="4.3511" y1="38.2601" x2="5.08" y2="38.989" width="0.254" layer="1"/>
 <wire x1="8.55621875" y1="35.799346875" x2="8.55621875" y2="34.417" width="0.508" layer="16"/>
 <via x="8.55621875" y="25.4" extent="1-16" drill="0.3048"/>
 <wire x1="8.55621875" y1="25.4" x2="8.55621875" y2="34.417" width="0.508" layer="16"/>
@@ -991,32 +1161,36 @@ design rules under a new name.</description>
 <wire x1="8.0319375" y1="34.94128125" x2="8.55621875" y2="34.417" width="0.508" layer="16"/>
 <wire x1="8.55621875" y1="34.417" x2="9.144" y2="35.00478125" width="0.508" layer="16"/>
 <wire x1="9.144" y1="35.00478125" x2="9.350784375" y2="35.00478125" width="0.508" layer="16"/>
+<contactref element="U1" pad="34"/>
+<contactref element="U1" pad="14"/>
+<contactref element="U1" pad="24"/>
+<contactref element="U1" pad="44"/>
+<contactref element="U1" pad="7"/>
+<contactref element="U1" pad="2"/>
+<wire x1="-4.4196" y1="6.9596" x2="10.273" y2="13.97" width="0" layer="19" extent="1-1"/>
+<wire x1="-12.5476" y1="4.4196" x2="-4.4196" y2="6.9596" width="0" layer="19" extent="1-1"/>
+<wire x1="-15.9004" y1="9.3726" x2="-12.5476" y2="4.4196" width="0" layer="19" extent="1-1"/>
+<wire x1="-15.9004" y1="13.3604" x2="-15.9004" y2="9.3726" width="0" layer="19" extent="1-1"/>
+<wire x1="-14.1478" y1="15.9004" x2="-15.9004" y2="13.3604" width="0" layer="19" extent="1-1"/>
+<wire x1="-6.1722" y1="15.9004" x2="-14.1478" y2="15.9004" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$3">
-<contactref element="U$1" pad="13"/>
 <contactref element="SW00" pad="2A"/>
 <contactref element="SW00" pad="2B"/>
-<contactref element="R1" pad="2"/>
-<wire x1="8.523" y1="13.97" x2="8.523" y2="19.05" width="0.254" layer="1"/>
-<wire x1="8.523" y1="19.05" x2="8.523" y2="22.606" width="0.254" layer="1"/>
-<wire x1="8.523" y1="22.606" x2="7.366" y2="23.763" width="0.254" layer="1"/>
-<wire x1="7.366" y1="30.48" x2="7.366" y2="23.763" width="0.254" layer="1"/>
-<wire x1="10.453159375" y1="34.31040625" x2="10.922" y2="33.841565625" width="0.254" layer="1"/>
-<wire x1="10.922" y1="33.0609875" x2="9.1314125" y2="31.2704" width="0.254" layer="1"/>
-<wire x1="10.922" y1="33.841565625" x2="10.922" y2="33.0609875" width="0.254" layer="1"/>
-<wire x1="9.1314125" y1="31.2704" x2="8.1564" y2="31.2704" width="0.254" layer="1"/>
-<wire x1="8.1564" y1="31.2704" x2="7.366" y2="30.48" width="0.254" layer="1"/>
 <wire x1="12.095" y1="10.398" x2="6.955" y2="10.398" width="0.254" layer="1"/>
 <wire x1="6.955" y1="10.398" x2="6.955" y2="12.402" width="0.254" layer="1"/>
-<wire x1="6.955" y1="12.402" x2="8.523" y2="13.97" width="0.254" layer="1"/>
+<contactref element="U1" pad="13"/>
+<contactref element="R1" pad="2"/>
+<wire x1="6.955" y1="12.402" x2="8.523" y2="13.97" width="0" layer="19" extent="1-1"/>
+<wire x1="-13.3604" y1="4.4196" x2="6.955" y2="10.398" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="UCAP">
-<contactref element="U$1" pad="6"/>
 <contactref element="C8" pad="1"/>
-<wire x1="7.1397125" y1="35.747784375" x2="5.958528125" y2="34.5666" width="0.254" layer="1"/>
 <wire x1="5.958528125" y1="34.5666" x2="5.9506125" y2="34.5666" width="0.254" layer="1"/>
 <wire x1="5.9506125" y1="34.5666" x2="4.826" y2="33.4419875" width="0.254" layer="1"/>
 <wire x1="4.826" y1="33.4419875" x2="4.826" y2="32.625" width="0.254" layer="1"/>
+<contactref element="U1" pad="6"/>
+<wire x1="-15.9004" y1="10.16" x2="4.826" y2="32.625" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$5">
 <contactref element="USB1" pad="D+"/>
@@ -1026,14 +1200,12 @@ design rules under a new name.</description>
 <wire x1="7.874" y1="57.898" x2="7.874" y2="52.945" width="0.254" layer="1"/>
 </signal>
 <signal name="N$6">
-<contactref element="U$1" pad="3"/>
 <contactref element="R4" pad="2"/>
 <wire x1="7.874" y1="51.195" x2="7.874" y2="47.752" width="0.254" layer="1"/>
 <via x="7.874" y="47.752" extent="1-16" drill="0.3048"/>
 <via x="3.81" y="36.195" extent="1-16" drill="0.3048"/>
 <wire x1="7.874" y1="47.752" x2="7.874" y2="39.862196875" width="0.254" layer="16"/>
 <wire x1="4.833896875" y1="36.82209375" x2="7.874" y2="39.862196875" width="0.254" layer="16"/>
-<wire x1="6.08648125" y1="36.815825" x2="5.985934375" y2="36.815825" width="0.254" layer="1"/>
 <wire x1="5.985934375" y1="36.815825" x2="5.6141375" y2="36.44918125" width="0.254" layer="1"/>
 <wire x1="5.6141375" y1="36.44918125" x2="5.60964375" y2="36.4492125" width="0.254" layer="1"/>
 <wire x1="5.60964375" y1="36.4492125" x2="5.42944375" y2="36.2715125" width="0.254" layer="1"/>
@@ -1042,6 +1214,8 @@ design rules under a new name.</description>
 <wire x1="3.729859375" y1="36.275140625" x2="3.81" y2="36.195" width="0.254" layer="1"/>
 <wire x1="3.81" y1="36.195" x2="4.206778125" y2="36.195" width="0.254" layer="16"/>
 <wire x1="4.833896875" y1="36.82209375" x2="4.206778125" y2="36.195" width="0.254" layer="16"/>
+<contactref element="U1" pad="3"/>
+<wire x1="-15.9004" y1="12.5476" x2="3.729859375" y2="36.275140625" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$7">
 <contactref element="USB1" pad="D-"/>
@@ -1051,18 +1225,18 @@ design rules under a new name.</description>
 <wire x1="10.325" y1="59.206" x2="9.525" y2="58.406" width="0.254" layer="1"/>
 </signal>
 <signal name="N$8">
-<contactref element="U$1" pad="4"/>
 <contactref element="R3" pad="2"/>
 <wire x1="9.525" y1="51.195" x2="9.525" y2="47.752" width="0.254" layer="1"/>
 <via x="9.525" y="47.752" extent="1-16" drill="0.3048"/>
 <wire x1="9.525" y1="47.752" x2="9.525" y2="40.475021875" width="0.254" layer="16"/>
 <via x="4.572" y="35.306" extent="1-16" drill="0.3048"/>
 <wire x1="4.97816875" y1="35.71216875" x2="4.572" y2="35.306" width="0.254" layer="1"/>
-<wire x1="6.437559375" y1="36.4598125" x2="6.437559375" y2="36.4333625" width="0.254" layer="1"/>
 <wire x1="6.437559375" y1="36.4333625" x2="5.716365625" y2="35.71216875" width="0.254" layer="1"/>
 <wire x1="4.97816875" y1="35.71216875" x2="5.716365625" y2="35.71216875" width="0.254" layer="1"/>
 <wire x1="4.572" y1="35.306" x2="4.57198125" y2="35.522003125" width="0.254" layer="16"/>
 <wire x1="9.525" y1="40.475021875" x2="4.57198125" y2="35.522003125" width="0.254" layer="16"/>
+<contactref element="U1" pad="4"/>
+<wire x1="-15.9004" y1="11.7602" x2="4.572" y2="35.306" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$9">
 <contactref element="SW01" pad="MX2"/>
@@ -1090,8 +1264,6 @@ design rules under a new name.</description>
 <wire x1="63.461" y1="29.347925" x2="63.461" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="63.461" y1="27.802075" x2="62.865" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="62.865" y1="27.206075" x2="62.865" y2="12.065" width="0.254" layer="16"/>
-<contactref element="U$1" pad="29"/>
-<wire x1="11.559209375" y1="40.808225" x2="13.041984375" y2="42.291" width="0.254" layer="1"/>
 <wire x1="13.041984375" y1="42.291" x2="17.272" y2="42.291" width="0.254" layer="1"/>
 <wire x1="17.272" y1="42.291" x2="18.542" y2="43.561" width="0.254" layer="1"/>
 <wire x1="18.542" y1="71.501" x2="20.701" y2="73.66" width="0.254" layer="1"/>
@@ -1100,6 +1272,8 @@ design rules under a new name.</description>
 <wire x1="60.96" y1="73.66" x2="62.865" y2="71.755" width="0.254" layer="16"/>
 <wire x1="62.865" y1="71.755" x2="62.865" y2="69.215" width="0.254" layer="16"/>
 <wire x1="18.542" y1="43.561" x2="18.542" y2="71.501" width="0.254" layer="1"/>
+<contactref element="U1" pad="29"/>
+<wire x1="-4.4196" y1="10.9474" x2="13.041984375" y2="42.291" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$12">
 <contactref element="SW02" pad="MX2"/>
@@ -1108,8 +1282,6 @@ design rules under a new name.</description>
 <wire x1="40.64" y1="14.605" x2="39.37" y2="13.335" width="0.254" layer="1"/>
 </signal>
 <signal name="N$14">
-<contactref element="U$1" pad="25"/>
-<wire x1="12.963515625" y1="39.384171875" x2="13.96534375" y2="40.386" width="0.254" layer="1"/>
 <wire x1="13.96534375" y1="40.386" x2="15.875" y2="40.386" width="0.254" layer="1"/>
 <wire x1="15.875" y1="40.386" x2="17.78" y2="38.481" width="0.254" layer="1"/>
 <contactref element="D1" pad="C"/>
@@ -1126,6 +1298,8 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="2.54" x2="39.37" y2="3.81" width="0.254" layer="1"/>
 <wire x1="39.37" y1="3.81" x2="39.37" y2="5.715" width="0.254" layer="1"/>
 <wire x1="38.1" y1="2.54" x2="38.1" y2="1.27" width="0.254" layer="1"/>
+<contactref element="U1" pad="25"/>
+<wire x1="-4.4196" y1="7.7724" x2="17.78" y2="3.81" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$15">
 <contactref element="SW03" pad="MX2"/>
@@ -1153,8 +1327,6 @@ design rules under a new name.</description>
 <wire x1="25.361" y1="29.347925" x2="25.361" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="25.361" y1="27.802075" x2="24.765" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="24.765" y1="27.206075" x2="24.765" y2="12.065" width="0.254" layer="16"/>
-<contactref element="U$1" pad="31"/>
-<wire x1="10.85705625" y1="41.52025" x2="12.64380625" y2="43.307" width="0.254" layer="1"/>
 <wire x1="12.64380625" y1="43.307" x2="16.637" y2="43.307" width="0.254" layer="1"/>
 <wire x1="16.637" y1="43.307" x2="17.399" y2="44.069" width="0.254" layer="1"/>
 <wire x1="17.399" y1="44.069" x2="17.399" y2="72.644" width="0.254" layer="1"/>
@@ -1162,6 +1334,8 @@ design rules under a new name.</description>
 <via x="18.542" y="73.787" extent="1-16" drill="0.35"/>
 <wire x1="18.542" y1="73.787" x2="23.114" y2="69.215" width="0.254" layer="16"/>
 <wire x1="23.114" y1="69.215" x2="24.765" y2="69.215" width="0.254" layer="16"/>
+<contactref element="U1" pad="31"/>
+<wire x1="-4.4196" y1="12.5476" x2="24.765" y2="12.065" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$18">
 <contactref element="SW04" pad="MX2"/>
@@ -1182,8 +1356,6 @@ design rules under a new name.</description>
 <wire x1="35.56" y1="33.655" x2="36.83" y2="32.385" width="0.254" layer="1"/>
 </signal>
 <signal name="N$26">
-<contactref element="U$1" pad="26"/>
-<wire x1="12.6124375" y1="39.740184375" x2="12.712990625" y2="39.740184375" width="0.254" layer="1"/>
 <wire x1="12.712990625" y1="39.740184375" x2="13.76520625" y2="40.7924" width="0.254" layer="1"/>
 <wire x1="16.1036" y1="40.7924" x2="18.288" y2="38.608" width="0.254" layer="1"/>
 <wire x1="13.76520625" y1="40.7924" x2="16.1036" y2="40.7924" width="0.254" layer="1"/>
@@ -1201,6 +1373,8 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="21.59" x2="38.1" y2="20.32" width="0.254" layer="1"/>
 <wire x1="39.37" y1="24.765" x2="39.37" y2="22.86" width="0.254" layer="1"/>
 <wire x1="39.37" y1="22.86" x2="38.1" y2="21.59" width="0.254" layer="1"/>
+<contactref element="U1" pad="26"/>
+<wire x1="-4.4196" y1="8.5598" x2="18.288" y2="22.352" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$27">
 <contactref element="SW07" pad="MX2"/>
@@ -1215,8 +1389,6 @@ design rules under a new name.</description>
 <wire x1="40.64" y1="52.705" x2="39.37" y2="51.435" width="0.254" layer="1"/>
 </signal>
 <signal name="N$32">
-<contactref element="U$1" pad="27"/>
-<wire x1="12.2613625" y1="40.096196875" x2="13.363965625" y2="41.1988" width="0.254" layer="1"/>
 <contactref element="D9" pad="C"/>
 <contactref element="D8" pad="C"/>
 <contactref element="D7" pad="C"/>
@@ -1231,6 +1403,8 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="40.64" x2="39.37" y2="41.91" width="0.254" layer="1"/>
 <wire x1="39.37" y1="41.91" x2="39.37" y2="43.815" width="0.254" layer="1"/>
 <wire x1="38.1" y1="40.64" x2="38.1" y2="39.37" width="0.254" layer="1"/>
+<contactref element="U1" pad="27"/>
+<wire x1="-4.4196" y1="9.3726" x2="13.363965625" y2="41.1988" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$33">
 <contactref element="SW09" pad="MX2"/>
@@ -1246,8 +1420,6 @@ design rules under a new name.</description>
 <wire x1="57.15" y1="70.485" x2="57.15" y2="70.4354" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$38">
-<contactref element="U$1" pad="28"/>
-<wire x1="11.910284375" y1="40.4522125" x2="13.114071875" y2="41.656" width="0.254" layer="1"/>
 <wire x1="17.526" y1="41.656" x2="19.177" y2="43.307" width="0.254" layer="1"/>
 <wire x1="13.114071875" y1="41.656" x2="17.526" y2="41.656" width="0.254" layer="1"/>
 <wire x1="55.88" y1="58.42" x2="57.15" y2="59.69" width="0.254" layer="1"/>
@@ -1264,6 +1436,8 @@ design rules under a new name.</description>
 <wire x1="39.37" y1="60.96" x2="38.1" y2="59.69" width="0.254" layer="1"/>
 <wire x1="38.1" y1="59.69" x2="38.1" y2="58.42" width="0.254" layer="1"/>
 <wire x1="20.574" y1="58.42" x2="38.1" y2="58.42" width="0.254" layer="1"/>
+<contactref element="U1" pad="28"/>
+<wire x1="-4.4196" y1="10.16" x2="13.114071875" y2="41.656" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$39">
 <contactref element="SW11" pad="MX2"/>
@@ -1277,8 +1451,6 @@ design rules under a new name.</description>
 <contactref element="SW02" pad="MX1"/>
 <contactref element="SW05" pad="MX1"/>
 <contactref element="SW08" pad="MX1"/>
-<contactref element="U$1" pad="30"/>
-<wire x1="11.20813125" y1="41.1642375" x2="12.84289375" y2="42.799" width="0.254" layer="1"/>
 <wire x1="43.815" y1="69.215" x2="43.815" y2="68.043925" width="0.254" layer="16"/>
 <wire x1="43.815" y1="68.043925" x2="44.411" y2="67.447925" width="0.254" layer="16"/>
 <wire x1="44.411" y1="67.447925" x2="44.411" y2="65.902075" width="0.254" layer="16"/>
@@ -1302,6 +1474,8 @@ design rules under a new name.</description>
 <wire x1="18.0086" y1="43.9166" x2="18.0086" y2="72.0503375" width="0.254" layer="1"/>
 <wire x1="20.2786625" y1="74.3204" x2="43.8122" y2="74.3204" width="0.254" layer="1"/>
 <wire x1="43.8122" y1="74.3204" x2="43.815" y2="74.3176" width="0.254" layer="1"/>
+<contactref element="U1" pad="30"/>
+<wire x1="-4.4196" y1="11.7602" x2="12.84289375" y2="42.799" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$42">
 <contactref element="SW12" pad="MX2"/>
@@ -1310,10 +1484,9 @@ design rules under a new name.</description>
 <wire x1="35.56" y1="71.755" x2="36.83" y2="70.485" width="0.254" layer="1"/>
 </signal>
 <signal name="N$4">
-<contactref element="U$1" pad="33"/>
+<contactref element="U1" pad="33"/>
 <contactref element="R2" pad="2"/>
-<wire x1="10.154903125" y1="42.232275" x2="12.446" y2="44.523371875" width="0.254" layer="1"/>
-<wire x1="12.446" y1="44.523371875" x2="12.446" y2="51.195" width="0.254" layer="1"/>
+<wire x1="-4.4196" y1="14.1478" x2="12.446" y2="51.195" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$11">
 <contactref element="USB1" pad="SHIELD@1"/>
@@ -1336,15 +1509,7 @@ design rules under a new name.</description>
 <signal name="GND">
 <contactref element="F1" pad="1"/>
 <contactref element="USB1" pad="GND"/>
-<contactref element="U$1" pad="43"/>
-<contactref element="U$1" pad="35"/>
-<contactref element="U$1" pad="23"/>
-<contactref element="U$1" pad="15"/>
-<contactref element="U$1" pad="TAB"/>
-<contactref element="U$1" pad="5"/>
 <contactref element="C8" pad="2"/>
-<wire x1="5.748734375" y1="39.080978125" x2="5.72265" y2="39.080978125" width="0.254" layer="1"/>
-<wire x1="8.5968375" y1="41.889590625" x2="8.5968375" y2="41.922609375" width="0.254" layer="1"/>
 <via x="7.874" y="65.151" extent="1-16" drill="0.3048"/>
 <contactref element="C3" pad="2"/>
 <contactref element="C4" pad="2"/>
@@ -1354,7 +1519,6 @@ design rules under a new name.</description>
 <contactref element="C9" pad="2"/>
 <wire x1="11.54071875" y1="35.289715625" x2="11.54071875" y2="34.94128125" width="0.254" layer="16"/>
 <wire x1="5.85828125" y1="43.83128125" x2="5.85828125" y2="43.391165625" width="0.254" layer="1"/>
-<via x="4.826" y="40.894" extent="1-16" drill="0.3048"/>
 <contactref element="Y1" pad="2"/>
 <contactref element="Y1" pad="4"/>
 <contactref element="C1" pad="1"/>
@@ -1372,24 +1536,11 @@ design rules under a new name.</description>
 <via x="14.986" y="25.4" extent="1-16" drill="0.3048"/>
 <wire x1="4.826" y1="30.875" x2="4.826" y2="29.21" width="0.254" layer="1"/>
 <via x="4.826" y="29.21" extent="1-16" drill="0.3048"/>
-<wire x1="8.5968375" y1="41.889590625" x2="8.50285625" y2="41.889590625" width="0.254" layer="1"/>
 <wire x1="8.50285625" y1="41.889590625" x2="8.127821875" y2="42.264625" width="0.254" layer="1"/>
 <wire x1="7.425121875" y1="42.264625" x2="6.885171875" y2="42.804575" width="0.254" layer="1"/>
 <wire x1="8.127821875" y1="42.264625" x2="7.425121875" y2="42.264625" width="0.254" layer="1"/>
-<wire x1="6.788634375" y1="36.1038" x2="6.8222" y2="36.1038" width="0.254" layer="1"/>
-<wire x1="6.8222" y1="36.1038" x2="6.851921875" y2="36.074078125" width="0.254" layer="1"/>
-<wire x1="6.85905" y1="36.074078125" x2="6.851921875" y2="36.074078125" width="0.254" layer="1"/>
 <wire x1="8.636" y1="37.951165625" x2="8.636" y2="38.1" width="0.254" layer="1"/>
-<wire x1="6.788634375" y1="36.1038" x2="5.269821875" y2="34.5849875" width="0.254" layer="1"/>
-<wire x1="5.269821875" y1="34.5849875" x2="5.0390125" y2="34.5849875" width="0.254" layer="1"/>
-<wire x1="4.826" y1="40.734434375" x2="4.826" y2="40.894" width="0.254" layer="16"/>
-<wire x1="5.748734375" y1="39.080978125" x2="4.826" y2="40.0037125" width="0.254" layer="1"/>
-<wire x1="4.826" y1="40.0037125" x2="4.826" y2="40.894" width="0.254" layer="1"/>
 <wire x1="10.16" y1="37.41474375" x2="10.23674375" y2="37.338" width="0.254" layer="1"/>
-<wire x1="11.165184375" y1="35.012559375" x2="10.87174375" y2="35.306" width="0.254" layer="1"/>
-<wire x1="6.788634375" y1="36.1038" x2="8.784834375" y2="38.1" width="0.254" layer="1"/>
-<wire x1="8.784834375" y1="38.1" x2="9.525" y2="38.1" width="0.254" layer="1"/>
-<wire x1="11.165184375" y1="35.012559375" x2="10.16" y2="36.01774375" width="0.254" layer="1"/>
 <wire x1="7.925" y1="67.55" x2="7.925" y2="65.202" width="0.508" layer="1"/>
 <wire x1="7.925" y1="65.202" x2="7.874" y2="65.151" width="0.508" layer="1"/>
 <polygon width="0.254" layer="1">
@@ -1405,8 +1556,33 @@ design rules under a new name.</description>
 <vertex x="-1.27" y="-1.27"/>
 </polygon>
 <via x="14.986" y="35.687" extent="1-16" drill="0.3048"/>
-<wire x1="8.784834375" y1="38.1" x2="8.636" y2="38.1" width="0" layer="19" extent="1-1"/>
-<wire x1="11.165184375" y1="35.012559375" x2="11.54071875" y2="34.94128125" width="0" layer="19" extent="1-16"/>
+<contactref element="U1" pad="15"/>
+<contactref element="U1" pad="23"/>
+<contactref element="U1" pad="35"/>
+<contactref element="U1" pad="43"/>
+<contactref element="U1" pad="5"/>
+<wire x1="7.925" y1="65.202" x2="13.335" y2="63.008" width="0" layer="19" extent="1-1"/>
+<wire x1="12.446" y1="52.945" x2="13.335" y2="61.341" width="0" layer="19" extent="1-1"/>
+<wire x1="5.85828125" y1="43.83128125" x2="12.446" y2="52.945" width="0" layer="19" extent="1-1"/>
+<wire x1="6.885171875" y1="42.804575" x2="5.85828125" y2="43.391165625" width="0" layer="19" extent="1-1"/>
+<wire x1="6.20671875" y1="39.480715625" x2="7.425121875" y2="42.264625" width="0" layer="19" extent="1-16"/>
+<wire x1="8.636" y1="38.1" x2="6.20671875" y2="39.480715625" width="0" layer="19" extent="1-16"/>
+<wire x1="10.16" y1="37.41474375" x2="8.636" y2="37.951165625" width="0" layer="19" extent="1-1"/>
+<wire x1="11.54071875" y1="35.289715625" x2="10.23674375" y2="37.338" width="0" layer="19" extent="1-16"/>
+<wire x1="6.366284375" y1="36.178715625" x2="8.636" y2="37.951165625" width="0" layer="19" extent="1-16"/>
+<wire x1="14.986" y1="35.687" x2="11.54071875" y2="35.289715625" width="0" layer="19" extent="16-16"/>
+<wire x1="14.33471875" y1="37.86228125" x2="14.986" y2="35.687" width="0" layer="19" extent="16-16"/>
+<wire x1="11.111" y1="29.5" x2="11.54071875" y2="34.94128125" width="0" layer="19" extent="1-16"/>
+<wire x1="12.961" y1="27.65" x2="11.111" y2="29.5" width="0" layer="19" extent="1-1"/>
+<wire x1="14.986" y1="27.7" x2="13.011" y2="27.7" width="0" layer="19" extent="1-1"/>
+<wire x1="4.826" y1="29.21" x2="8.636" y2="29.45" width="0" layer="19" extent="1-1"/>
+<wire x1="12.095" y1="8.398" x2="14.986" y2="25.4" width="0" layer="19" extent="1-1"/>
+<wire x1="6.955" y1="8.398" x2="12.095" y2="8.398" width="0" layer="19" extent="1-1"/>
+<wire x1="-4.4196" y1="6.1722" x2="6.955" y2="8.398" width="0" layer="19" extent="1-1"/>
+<wire x1="-11.7602" y1="4.4196" x2="-4.4196" y2="6.1722" width="0" layer="19" extent="1-1"/>
+<wire x1="-15.9004" y1="10.9474" x2="-11.7602" y2="4.4196" width="0" layer="19" extent="1-1"/>
+<wire x1="-13.3604" y1="15.9004" x2="-15.9004" y2="10.9474" width="0" layer="19" extent="1-1"/>
+<wire x1="-6.9596" y1="15.9004" x2="-13.3604" y2="15.9004" width="0" layer="19" extent="1-1"/>
 </signal>
 </signals>
 <mfgpreviewcolors>

--- a/PCB/MacroPad.brd
+++ b/PCB/MacroPad.brd
@@ -153,8 +153,8 @@
 <wire x1="76.2" y1="0" x2="76.2" y2="76.2" width="0" layer="20"/>
 <wire x1="76.2" y1="76.2" x2="0" y2="76.19" width="0" layer="20"/>
 <wire x1="0" y1="76.19" x2="0" y2="0" width="0" layer="20"/>
-<text x="38.1" y="2.54" size="1.778" layer="22" rot="MR0" align="bottom-center">v20190525</text>
-<text x="9.525" y="38.1" size="1.778" layer="25" align="center">⬅</text>
+<text x="38.1" y="2.54" size="1.778" layer="22" rot="MR0" align="bottom-center">v20190608</text>
+<circle x="3.81" y="38.1" radius="0.127" width="0.254" layer="21"/>
 </plain>
 <libraries>
 <library name="Components">
@@ -861,11 +861,11 @@ design rules under a new name.</description>
 <attribute name="NAME" x="14.46869375" y="37.952065625" size="1" layer="26" ratio="13" rot="MR225" align="bottom-center"/>
 <attribute name="OC_NEWARK" value="unknown" x="14.986" y="38.481" size="1.778" layer="28" rot="MR225" display="off"/>
 </element>
-<element name="C3" library="Components" package="C0603" value="1u" x="3.556" y="30.48" smashed="yes" rot="R270">
-<attribute name="MF" value="" x="3.556" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="MPN" value="" x="3.556" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="NAME" x="4.206" y="30.391" size="1" layer="25" ratio="13" rot="R270" align="bottom-center"/>
-<attribute name="OC_NEWARK" value="unknown" x="3.556" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="C3" library="Components" package="C0603" value="1u" x="3.175" y="30.48" smashed="yes" rot="R270">
+<attribute name="MF" value="" x="3.175" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MPN" value="" x="3.175" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="3.825" y="30.391" size="1" layer="25" ratio="13" rot="R270" align="bottom-center"/>
+<attribute name="OC_NEWARK" value="unknown" x="3.175" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
 <element name="F1" library="USB" package="F0805" value="" x="13.335" y="64.008" smashed="yes" rot="R90">
 <attribute name="MF" value="" x="13.335" y="64.008" size="1.778" layer="27" rot="R90" display="off"/>
@@ -989,51 +989,39 @@ design rules under a new name.</description>
 <attribute name="OC_NEWARK" value="unknown" x="5.969" y="45.085" size="1.778" layer="27" rot="R226" display="off"/>
 </element>
 <element name="D12" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="36.83" y="66.675" smashed="yes" rot="R270">
-<attribute name="NAME" x="38.1" y="69.215" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="36.576" y="68.707" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D1" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="57.15" y="9.525" smashed="yes" rot="R270">
-<attribute name="NAME" x="58.42" y="12.065" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="56.896" y="11.557" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D2" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="39.37" y="9.525" smashed="yes" rot="R270">
-<attribute name="NAME" x="40.64" y="12.065" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="39.116" y="11.557" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D3" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="36.83" y="9.525" smashed="yes" rot="R270">
-<attribute name="NAME" x="38.1" y="12.065" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="36.576" y="11.557" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D4" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="57.15" y="28.575" smashed="yes" rot="R270">
-<attribute name="NAME" x="58.42" y="31.115" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="56.896" y="30.607" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D5" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="39.37" y="28.575" smashed="yes" rot="R270">
-<attribute name="NAME" x="40.64" y="31.115" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="39.116" y="30.607" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D6" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="36.83" y="28.575" smashed="yes" rot="R270">
-<attribute name="NAME" x="38.1" y="31.115" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="36.576" y="30.607" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D7" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="57.15" y="47.625" smashed="yes" rot="R270">
-<attribute name="NAME" x="58.42" y="50.165" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="56.896" y="49.657" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D8" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="39.37" y="47.625" smashed="yes" rot="R270">
-<attribute name="NAME" x="40.64" y="50.165" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="39.116" y="49.657" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D9" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="36.83" y="47.625" smashed="yes" rot="R270">
-<attribute name="NAME" x="38.1" y="50.165" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="36.576" y="49.657" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D10" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="57.15" y="66.675" smashed="yes" rot="R270">
-<attribute name="NAME" x="58.42" y="69.215" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="56.896" y="68.707" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="D11" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="39.37" y="66.675" smashed="yes" rot="R270">
-<attribute name="NAME" x="40.64" y="69.215" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="39.116" y="68.707" size="0.6096" layer="21" rot="R270"/>
 </element>
 <element name="U1" library="ATMEGA32U4-AUR" package="QFP80P1200X1200X120-44N" value="ATMEGA32U4-AUR" x="9.525" y="38.1" smashed="yes" rot="R45">
@@ -1197,9 +1185,9 @@ design rules under a new name.</description>
 </signal>
 <signal name="UCAP">
 <contactref element="C3" pad="1"/>
-<wire x1="3.556" y1="32.131" x2="3.556" y2="31.355" width="0.254" layer="1"/>
+<wire x1="3.175" y1="31.75" x2="3.175" y2="31.355" width="0.254" layer="1"/>
 <contactref element="U1" pad="6"/>
-<wire x1="5.465921875" y1="34.040921875" x2="3.556" y2="32.131" width="0.254" layer="1"/>
+<wire x1="5.465921875" y1="34.040921875" x2="3.175" y2="31.75" width="0.254" layer="1"/>
 </signal>
 <signal name="N$5">
 <contactref element="USB1" pad="D+"/>
@@ -1390,7 +1378,6 @@ design rules under a new name.</description>
 <contactref element="D9" pad="C"/>
 <contactref element="D8" pad="C"/>
 <contactref element="D7" pad="C"/>
-<wire x1="23.368" y1="39.37" x2="38.1" y2="39.37" width="0.254" layer="1"/>
 <wire x1="38.1" y1="39.37" x2="55.88" y2="39.37" width="0.254" layer="1"/>
 <wire x1="55.88" y1="39.37" x2="57.15" y2="40.64" width="0.254" layer="1"/>
 <wire x1="57.15" y1="40.64" x2="57.15" y2="43.815" width="0.254" layer="1"/>
@@ -1401,8 +1388,11 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="40.64" x2="38.1" y2="39.37" width="0.254" layer="1"/>
 <contactref element="U1" pad="27"/>
 <wire x1="14.14085" y1="41.602296875" x2="16.480553125" y2="43.942" width="0.254" layer="1"/>
-<wire x1="16.480553125" y1="43.942" x2="18.796" y2="43.942" width="0.254" layer="1"/>
-<wire x1="18.796" y1="43.942" x2="23.368" y2="39.37" width="0.254" layer="1"/>
+<wire x1="18.796" y1="43.942" x2="16.480553125" y2="43.942" width="0.254" layer="1"/>
+<wire x1="18.796" y1="43.942" x2="20.193" y2="42.545" width="0.254" layer="1"/>
+<wire x1="21.59" y1="39.37" x2="20.193" y2="40.767" width="0.254" layer="1"/>
+<wire x1="20.193" y1="40.767" x2="20.193" y2="42.545" width="0.254" layer="1"/>
+<wire x1="38.1" y1="39.37" x2="21.59" y2="39.37" width="0.254" layer="1"/>
 </signal>
 <signal name="N$33">
 <contactref element="SW09" pad="MX2"/>

--- a/PCB/MacroPad.brd
+++ b/PCB/MacroPad.brd
@@ -169,15 +169,6 @@
 <rectangle x1="-0.8" y1="-0.4" x2="-0.45" y2="0.4" layer="51"/>
 <rectangle x1="0.45" y1="-0.4" x2="0.8" y2="0.4" layer="51"/>
 </package>
-<package name="DFN0603-2">
-<description>DFN0603-2</description>
-<wire x1="0.305" y1="-0.25" x2="-0.305" y2="-0.25" width="0.1" layer="21"/>
-<wire x1="-0.305" y1="0.25" x2="0.305" y2="0.25" width="0.1" layer="21"/>
-<smd name="C" x="-0.19" y="0" dx="0.23" dy="0.3" layer="1"/>
-<smd name="A" x="0.19" y="0" dx="0.23" dy="0.3" layer="1"/>
-<text x="0" y="0.5" size="1" layer="21" font="vector" ratio="13" rot="R180" align="top-center">&gt;NAME</text>
-<text x="-0.635" y="0" size="0.75" layer="21" font="vector" ratio="13" align="center-right">K</text>
-</package>
 <package name="R0603">
 <wire x1="-0.725" y1="0.35" x2="0.725" y2="0.35" width="0.1016" layer="51"/>
 <wire x1="0.725" y1="-0.35" x2="-0.725" y2="-0.35" width="0.1016" layer="51"/>
@@ -427,6 +418,32 @@
 </package>
 </packages>
 </library>
+<library name="adafruit" urn="urn:adsk.eagle:library:420">
+<packages>
+<package name="DO-1N4148" urn="urn:adsk.eagle:footprint:6240102/1" library_version="2">
+<wire x1="-2.54" y1="0.762" x2="2.54" y2="0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0.762" x2="2.54" y2="0" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0" x2="2.54" y2="-0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="-0.762" x2="-2.54" y2="-0.762" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="-0.762" x2="-2.54" y2="0" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-2.54" y2="0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0" x2="2.794" y2="0" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-2.794" y2="0" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="0.635" x2="1.905" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="A" x="-3.81" y="0" drill="0.9"/>
+<pad name="C" x="3.81" y="0" drill="0.9"/>
+<text x="-2.54" y="1.27" size="0.4064" layer="25">&gt;Name</text>
+<text x="-2.032" y="-0.254" size="0.6096" layer="21">&gt;Value</text>
+</package>
+</packages>
+<packages3d>
+<package3d name="DO-1N4148" urn="urn:adsk.eagle:package:6240748/1" type="box" library_version="2">
+<packageinstances>
+<packageinstance name="DO-1N4148"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
 </libraries>
 <attributes>
 </attributes>
@@ -668,66 +685,6 @@ design rules under a new name.</description>
 <attribute name="NAME" x="5.476" y="31.661" size="1" layer="25" ratio="13" rot="R270" align="bottom-center"/>
 <attribute name="OC_NEWARK" value="unknown" x="4.826" y="31.75" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="D1" library="Components" package="DFN0603-2" value="" x="66.04" y="19.05" smashed="yes">
-<attribute name="MF" value="" x="66.04" y="19.05" size="1.778" layer="27" display="off"/>
-<attribute name="MPN" value="" x="66.04" y="19.05" size="1.778" layer="27" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="66.04" y="19.05" size="1.778" layer="27" display="off"/>
-</element>
-<element name="D10" library="Components" package="DFN0603-2" value="" x="57.15" y="68.58" smashed="yes" rot="R90">
-<attribute name="MF" value="" x="57.15" y="68.58" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="MPN" value="" x="57.15" y="68.58" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="57.15" y="68.58" size="1.778" layer="27" rot="R90" display="off"/>
-</element>
-<element name="D11" library="Components" package="DFN0603-2" value="" x="39.37" y="68.58" smashed="yes" rot="R90">
-<attribute name="MF" value="" x="39.37" y="68.58" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="MPN" value="" x="39.37" y="68.58" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="39.37" y="68.58" size="1.778" layer="27" rot="R90" display="off"/>
-</element>
-<element name="D12" library="Components" package="DFN0603-2" value="" x="36.83" y="68.58" smashed="yes" rot="R90">
-<attribute name="MF" value="" x="36.83" y="68.58" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="MPN" value="" x="36.83" y="68.58" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="36.83" y="68.58" size="1.778" layer="27" rot="R90" display="off"/>
-</element>
-<element name="D2" library="Components" package="DFN0603-2" value="" x="50.165" y="17.399" smashed="yes" rot="R270">
-<attribute name="MF" value="" x="50.165" y="17.399" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="MPN" value="" x="50.165" y="17.399" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="50.165" y="17.399" size="1.778" layer="27" rot="R270" display="off"/>
-</element>
-<element name="D3" library="Components" package="DFN0603-2" value="" x="31.115" y="17.399" smashed="yes" rot="R270">
-<attribute name="MF" value="" x="31.115" y="17.399" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="MPN" value="" x="31.115" y="17.399" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="31.115" y="17.399" size="1.778" layer="27" rot="R270" display="off"/>
-</element>
-<element name="D4" library="Components" package="DFN0603-2" value="" x="66.04" y="38.1" smashed="yes">
-<attribute name="MF" value="" x="66.04" y="38.1" size="1.778" layer="27" display="off"/>
-<attribute name="MPN" value="" x="66.04" y="38.1" size="1.778" layer="27" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="66.04" y="38.1" size="1.778" layer="27" display="off"/>
-</element>
-<element name="D5" library="Components" package="DFN0603-2" value="" x="50.165" y="36.449" smashed="yes" rot="R270">
-<attribute name="MF" value="" x="50.165" y="36.449" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="MPN" value="" x="50.165" y="36.449" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="50.165" y="36.449" size="1.778" layer="27" rot="R270" display="off"/>
-</element>
-<element name="D6" library="Components" package="DFN0603-2" value="" x="31.115" y="36.449" smashed="yes" rot="R270">
-<attribute name="MF" value="" x="31.115" y="36.449" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="MPN" value="" x="31.115" y="36.449" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="31.115" y="36.449" size="1.778" layer="27" rot="R270" display="off"/>
-</element>
-<element name="D7" library="Components" package="DFN0603-2" value="" x="66.04" y="57.15" smashed="yes">
-<attribute name="MF" value="" x="66.04" y="57.15" size="1.778" layer="27" display="off"/>
-<attribute name="MPN" value="" x="66.04" y="57.15" size="1.778" layer="27" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="66.04" y="57.15" size="1.778" layer="27" display="off"/>
-</element>
-<element name="D8" library="Components" package="DFN0603-2" value="" x="50.165" y="55.499" smashed="yes" rot="R270">
-<attribute name="MF" value="" x="50.165" y="55.499" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="MPN" value="" x="50.165" y="55.499" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="50.165" y="55.499" size="1.778" layer="27" rot="R270" display="off"/>
-</element>
-<element name="D9" library="Components" package="DFN0603-2" value="" x="31.115" y="55.499" smashed="yes" rot="R270">
-<attribute name="MF" value="" x="31.115" y="55.499" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="MPN" value="" x="31.115" y="55.499" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="OC_NEWARK" value="unknown" x="31.115" y="55.499" size="1.778" layer="27" rot="R270" display="off"/>
-</element>
 <element name="F1" library="USB" package="F0805" value="" x="13.335" y="64.008" smashed="yes" rot="R90">
 <attribute name="MF" value="" x="13.335" y="64.008" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="MPN" value="" x="13.335" y="64.008" size="1.778" layer="27" rot="R90" display="off"/>
@@ -860,6 +817,54 @@ design rules under a new name.</description>
 <attribute name="MPN" value="" x="7.493" y="43.434" size="1.778" layer="27" rot="R226" display="off"/>
 <attribute name="NAME" x="6.35729375" y="42.160940625" size="1" layer="25" ratio="13" rot="R226" align="center-left"/>
 <attribute name="OC_NEWARK" value="unknown" x="7.493" y="43.434" size="1.778" layer="27" rot="R226" display="off"/>
+</element>
+<element name="D12" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="36.83" y="66.675" smashed="yes" rot="R270">
+<attribute name="NAME" x="38.1" y="69.215" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="36.576" y="68.707" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D1" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="57.15" y="9.525" smashed="yes" rot="R270">
+<attribute name="NAME" x="58.42" y="12.065" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="56.896" y="11.557" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D2" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="39.37" y="9.525" smashed="yes" rot="R270">
+<attribute name="NAME" x="40.64" y="12.065" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="39.116" y="11.557" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D3" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="36.83" y="9.525" smashed="yes" rot="R270">
+<attribute name="NAME" x="38.1" y="12.065" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="36.576" y="11.557" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D4" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="57.15" y="28.575" smashed="yes" rot="R270">
+<attribute name="NAME" x="58.42" y="31.115" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="56.896" y="30.607" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D5" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="39.37" y="28.575" smashed="yes" rot="R270">
+<attribute name="NAME" x="40.64" y="31.115" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="39.116" y="30.607" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D6" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="36.83" y="28.575" smashed="yes" rot="R270">
+<attribute name="NAME" x="38.1" y="31.115" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="36.576" y="30.607" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D7" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="57.15" y="47.625" smashed="yes" rot="R270">
+<attribute name="NAME" x="58.42" y="50.165" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="56.896" y="49.657" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D8" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="39.37" y="47.625" smashed="yes" rot="R270">
+<attribute name="NAME" x="40.64" y="50.165" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="39.116" y="49.657" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D9" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="36.83" y="47.625" smashed="yes" rot="R270">
+<attribute name="NAME" x="38.1" y="50.165" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="36.576" y="49.657" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D10" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="57.15" y="66.675" smashed="yes" rot="R270">
+<attribute name="NAME" x="58.42" y="69.215" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="56.896" y="68.707" size="0.6096" layer="21" rot="R270"/>
+</element>
+<element name="D11" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="39.37" y="66.675" smashed="yes" rot="R270">
+<attribute name="NAME" x="40.64" y="69.215" size="0.4064" layer="25" rot="R270"/>
+<attribute name="VALUE" x="39.116" y="68.707" size="0.6096" layer="21" rot="R270"/>
 </element>
 </elements>
 <signals>
@@ -1062,9 +1067,8 @@ design rules under a new name.</description>
 <signal name="N$9">
 <contactref element="SW01" pad="MX2"/>
 <contactref element="D1" pad="A"/>
-<wire x1="66.23" y1="19.05" x2="67.945" y2="19.05" width="0.254" layer="1"/>
-<wire x1="67.945" y1="19.05" x2="69.215" y2="17.78" width="0.254" layer="1"/>
-<wire x1="69.215" y1="17.78" x2="69.215" y2="14.605" width="0.254" layer="1"/>
+<wire x1="69.215" y1="14.605" x2="58.42" y2="14.605" width="0.254" layer="1"/>
+<wire x1="58.42" y1="14.605" x2="57.15" y2="13.335" width="0.254" layer="1"/>
 </signal>
 <signal name="N$10">
 <contactref element="SW01" pad="MX1"/>
@@ -1087,54 +1091,47 @@ design rules under a new name.</description>
 <wire x1="63.461" y1="27.802075" x2="62.865" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="62.865" y1="27.206075" x2="62.865" y2="12.065" width="0.254" layer="16"/>
 <contactref element="U$1" pad="29"/>
-<wire x1="11.559209375" y1="40.808225" x2="13.930984375" y2="43.18" width="0.254" layer="1"/>
-<wire x1="13.930984375" y1="43.18" x2="15.24" y2="43.18" width="0.254" layer="1"/>
-<via x="15.24" y="43.18" extent="1-16" drill="0.35"/>
-<wire x1="15.24" y1="43.18" x2="19.05" y2="43.18" width="0.254" layer="16"/>
-<via x="19.05" y="43.18" extent="1-16" drill="0.35"/>
-<wire x1="19.05" y1="43.18" x2="55.88" y2="43.18" width="0.254" layer="1"/>
-<wire x1="55.88" y1="43.18" x2="57.15" y2="44.45" width="0.254" layer="1"/>
-<wire x1="57.15" y1="44.45" x2="57.15" y2="48.895" width="0.254" layer="1"/>
-<wire x1="57.15" y1="48.895" x2="58.42" y2="50.165" width="0.254" layer="1"/>
-<wire x1="58.42" y1="50.165" x2="62.865" y2="50.165" width="0.254" layer="1"/>
+<wire x1="11.559209375" y1="40.808225" x2="13.041984375" y2="42.291" width="0.254" layer="1"/>
+<wire x1="13.041984375" y1="42.291" x2="17.272" y2="42.291" width="0.254" layer="1"/>
+<wire x1="17.272" y1="42.291" x2="18.542" y2="43.561" width="0.254" layer="1"/>
+<wire x1="18.542" y1="71.501" x2="20.701" y2="73.66" width="0.254" layer="1"/>
+<wire x1="20.701" y1="73.66" x2="60.96" y2="73.66" width="0.254" layer="1"/>
+<via x="60.96" y="73.66" extent="1-16" drill="0.35"/>
+<wire x1="60.96" y1="73.66" x2="62.865" y2="71.755" width="0.254" layer="16"/>
+<wire x1="62.865" y1="71.755" x2="62.865" y2="69.215" width="0.254" layer="16"/>
+<wire x1="18.542" y1="43.561" x2="18.542" y2="71.501" width="0.254" layer="1"/>
 </signal>
 <signal name="N$12">
 <contactref element="SW02" pad="MX2"/>
 <contactref element="D2" pad="A"/>
-<wire x1="50.165" y1="17.209" x2="50.165" y2="14.605" width="0.254" layer="1"/>
+<wire x1="50.165" y1="14.605" x2="40.64" y2="14.605" width="0.254" layer="1"/>
+<wire x1="40.64" y1="14.605" x2="39.37" y2="13.335" width="0.254" layer="1"/>
 </signal>
 <signal name="N$14">
-<contactref element="D2" pad="C"/>
-<contactref element="D3" pad="C"/>
-<contactref element="D1" pad="C"/>
 <contactref element="U$1" pad="25"/>
 <wire x1="12.963515625" y1="39.384171875" x2="13.96534375" y2="40.386" width="0.254" layer="1"/>
 <wire x1="13.96534375" y1="40.386" x2="15.875" y2="40.386" width="0.254" layer="1"/>
-<wire x1="15.875" y1="40.386" x2="16.7005" y2="39.5605" width="0.254" layer="1"/>
-<wire x1="16.7005" y1="39.5605" x2="16.93" y2="39.331" width="0.254" layer="1"/>
-<wire x1="50.165" y1="19.05" x2="49.784" y2="19.05" width="0.254" layer="1"/>
-<wire x1="49.784" y1="19.05" x2="31.496" y2="19.05" width="0.254" layer="1"/>
-<wire x1="31.496" y1="19.05" x2="31.115" y2="19.05" width="0.254" layer="1"/>
-<wire x1="31.115" y1="19.05" x2="30.734" y2="19.05" width="0.254" layer="1"/>
-<wire x1="31.115" y1="17.589" x2="31.115" y2="18.669" width="0.254" layer="1"/>
-<wire x1="31.115" y1="18.669" x2="31.115" y2="19.05" width="0.254" layer="1"/>
-<wire x1="50.165" y1="17.589" x2="50.165" y2="18.669" width="0.254" layer="1"/>
-<wire x1="50.165" y1="18.669" x2="50.165" y2="19.05" width="0.254" layer="1"/>
-<wire x1="65.85" y1="19.05" x2="50.546" y2="19.05" width="0.254" layer="1"/>
-<wire x1="50.546" y1="19.05" x2="50.165" y2="19.05" width="0.254" layer="1"/>
-<wire x1="30.734" y1="19.05" x2="31.115" y2="18.669" width="0.254" layer="1"/>
-<wire x1="31.496" y1="19.05" x2="31.115" y2="18.669" width="0.254" layer="1"/>
-<wire x1="49.784" y1="19.05" x2="50.165" y2="18.669" width="0.254" layer="1"/>
-<wire x1="50.546" y1="19.05" x2="50.165" y2="18.669" width="0.254" layer="1"/>
-<wire x1="16.93" y1="39.331" x2="17.78" y2="38.481" width="0.254" layer="1"/>
-<wire x1="17.78" y1="20.32" x2="19.05" y2="19.05" width="0.254" layer="1"/>
-<wire x1="17.78" y1="38.481" x2="17.78" y2="20.32" width="0.254" layer="1"/>
-<wire x1="19.05" y1="19.05" x2="30.734" y2="19.05" width="0.254" layer="1"/>
+<wire x1="15.875" y1="40.386" x2="17.78" y2="38.481" width="0.254" layer="1"/>
+<contactref element="D1" pad="C"/>
+<contactref element="D2" pad="C"/>
+<contactref element="D3" pad="C"/>
+<wire x1="17.78" y1="3.81" x2="20.32" y2="1.27" width="0.254" layer="1"/>
+<wire x1="20.32" y1="1.27" x2="38.1" y2="1.27" width="0.254" layer="1"/>
+<wire x1="38.1" y1="1.27" x2="55.88" y2="1.27" width="0.254" layer="1"/>
+<wire x1="55.88" y1="1.27" x2="57.15" y2="2.54" width="0.254" layer="1"/>
+<wire x1="57.15" y1="2.54" x2="57.15" y2="5.715" width="0.254" layer="1"/>
+<wire x1="17.78" y1="38.481" x2="17.78" y2="3.81" width="0.254" layer="1"/>
+<wire x1="36.83" y1="5.715" x2="36.83" y2="3.81" width="0.254" layer="1"/>
+<wire x1="36.83" y1="3.81" x2="38.1" y2="2.54" width="0.254" layer="1"/>
+<wire x1="38.1" y1="2.54" x2="39.37" y2="3.81" width="0.254" layer="1"/>
+<wire x1="39.37" y1="3.81" x2="39.37" y2="5.715" width="0.254" layer="1"/>
+<wire x1="38.1" y1="2.54" x2="38.1" y2="1.27" width="0.254" layer="1"/>
 </signal>
 <signal name="N$15">
 <contactref element="SW03" pad="MX2"/>
 <contactref element="D3" pad="A"/>
-<wire x1="31.115" y1="17.209" x2="31.115" y2="14.605" width="0.254" layer="1"/>
+<wire x1="31.115" y1="14.605" x2="35.56" y2="14.605" width="0.254" layer="1"/>
+<wire x1="35.56" y1="14.605" x2="36.83" y2="13.335" width="0.254" layer="1"/>
 </signal>
 <signal name="N$16">
 <contactref element="SW03" pad="MX1"/>
@@ -1157,141 +1154,123 @@ design rules under a new name.</description>
 <wire x1="25.361" y1="27.802075" x2="24.765" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="24.765" y1="27.206075" x2="24.765" y2="12.065" width="0.254" layer="16"/>
 <contactref element="U$1" pad="31"/>
-<wire x1="10.85705625" y1="41.52025" x2="15.05680625" y2="45.72" width="0.254" layer="1"/>
-<wire x1="15.05680625" y1="45.72" x2="15.24" y2="45.72" width="0.254" layer="1"/>
-<via x="15.24" y="45.72" extent="1-16" drill="0.35"/>
-<wire x1="15.24" y1="45.72" x2="19.05" y2="45.72" width="0.254" layer="16"/>
-<via x="19.05" y="45.72" extent="1-16" drill="0.35"/>
-<wire x1="19.05" y1="45.72" x2="19.05" y2="48.895" width="0.254" layer="1"/>
-<wire x1="19.05" y1="48.895" x2="20.32" y2="50.165" width="0.254" layer="1"/>
-<wire x1="20.32" y1="50.165" x2="24.765" y2="50.165" width="0.254" layer="1"/>
+<wire x1="10.85705625" y1="41.52025" x2="12.64380625" y2="43.307" width="0.254" layer="1"/>
+<wire x1="12.64380625" y1="43.307" x2="16.637" y2="43.307" width="0.254" layer="1"/>
+<wire x1="16.637" y1="43.307" x2="17.399" y2="44.069" width="0.254" layer="1"/>
+<wire x1="17.399" y1="44.069" x2="17.399" y2="72.644" width="0.254" layer="1"/>
+<wire x1="17.399" y1="72.644" x2="18.542" y2="73.787" width="0.254" layer="1"/>
+<via x="18.542" y="73.787" extent="1-16" drill="0.35"/>
+<wire x1="18.542" y1="73.787" x2="23.114" y2="69.215" width="0.254" layer="16"/>
+<wire x1="23.114" y1="69.215" x2="24.765" y2="69.215" width="0.254" layer="16"/>
 </signal>
 <signal name="N$18">
 <contactref element="SW04" pad="MX2"/>
 <contactref element="D4" pad="A"/>
-<wire x1="66.23" y1="38.1" x2="67.818" y2="38.1" width="0.254" layer="1"/>
-<wire x1="67.818" y1="38.1" x2="69.215" y2="36.703" width="0.254" layer="1"/>
-<wire x1="69.215" y1="36.703" x2="69.215" y2="33.655" width="0.254" layer="1"/>
+<wire x1="69.215" y1="33.655" x2="58.42" y2="33.655" width="0.254" layer="1"/>
+<wire x1="58.42" y1="33.655" x2="57.15" y2="32.385" width="0.254" layer="1"/>
 </signal>
 <signal name="N$21">
 <contactref element="SW05" pad="MX2"/>
 <contactref element="D5" pad="A"/>
-<wire x1="50.165" y1="36.259" x2="50.165" y2="33.655" width="0.254" layer="1"/>
+<wire x1="50.165" y1="33.655" x2="40.64" y2="33.655" width="0.254" layer="1"/>
+<wire x1="40.64" y1="33.655" x2="39.37" y2="32.385" width="0.254" layer="1"/>
 </signal>
 <signal name="N$24">
 <contactref element="SW06" pad="MX2"/>
 <contactref element="D6" pad="A"/>
-<wire x1="31.115" y1="36.259" x2="31.115" y2="33.655" width="0.254" layer="1"/>
+<wire x1="31.115" y1="33.655" x2="35.56" y2="33.655" width="0.254" layer="1"/>
+<wire x1="35.56" y1="33.655" x2="36.83" y2="32.385" width="0.254" layer="1"/>
 </signal>
 <signal name="N$26">
-<contactref element="D6" pad="C"/>
-<contactref element="D5" pad="C"/>
-<contactref element="D4" pad="C"/>
 <contactref element="U$1" pad="26"/>
 <wire x1="12.6124375" y1="39.740184375" x2="12.712990625" y2="39.740184375" width="0.254" layer="1"/>
 <wire x1="12.712990625" y1="39.740184375" x2="13.76520625" y2="40.7924" width="0.254" layer="1"/>
-<wire x1="50.165" y1="38.1" x2="49.784" y2="38.1" width="0.254" layer="1"/>
-<wire x1="49.784" y1="38.1" x2="31.496" y2="38.1" width="0.254" layer="1"/>
-<wire x1="31.496" y1="38.1" x2="31.115" y2="38.1" width="0.254" layer="1"/>
-<wire x1="31.115" y1="38.1" x2="30.734" y2="38.1" width="0.254" layer="1"/>
-<wire x1="31.115" y1="36.639" x2="31.115" y2="37.719" width="0.254" layer="1"/>
-<wire x1="31.115" y1="37.719" x2="31.115" y2="38.1" width="0.254" layer="1"/>
-<wire x1="50.165" y1="36.639" x2="50.165" y2="37.719" width="0.254" layer="1"/>
-<wire x1="50.165" y1="37.719" x2="50.165" y2="38.1" width="0.254" layer="1"/>
-<wire x1="65.85" y1="38.1" x2="50.546" y2="38.1" width="0.254" layer="1"/>
-<wire x1="50.546" y1="38.1" x2="50.165" y2="38.1" width="0.254" layer="1"/>
-<wire x1="49.784" y1="38.1" x2="50.165" y2="37.719" width="0.254" layer="1"/>
-<wire x1="50.546" y1="38.1" x2="50.165" y2="37.719" width="0.254" layer="1"/>
-<wire x1="30.734" y1="38.1" x2="31.115" y2="37.719" width="0.254" layer="1"/>
-<wire x1="31.496" y1="38.1" x2="31.115" y2="37.719" width="0.254" layer="1"/>
-<wire x1="16.1036" y1="40.7924" x2="18.796" y2="38.1" width="0.254" layer="1"/>
+<wire x1="16.1036" y1="40.7924" x2="18.288" y2="38.608" width="0.254" layer="1"/>
 <wire x1="13.76520625" y1="40.7924" x2="16.1036" y2="40.7924" width="0.254" layer="1"/>
-<wire x1="18.796" y1="38.1" x2="30.734" y2="38.1" width="0.254" layer="1"/>
+<contactref element="D4" pad="C"/>
+<contactref element="D5" pad="C"/>
+<contactref element="D6" pad="C"/>
+<wire x1="18.288" y1="22.352" x2="20.32" y2="20.32" width="0.254" layer="1"/>
+<wire x1="20.32" y1="20.32" x2="38.1" y2="20.32" width="0.254" layer="1"/>
+<wire x1="38.1" y1="20.32" x2="55.88" y2="20.32" width="0.254" layer="1"/>
+<wire x1="55.88" y1="20.32" x2="57.15" y2="21.59" width="0.254" layer="1"/>
+<wire x1="57.15" y1="21.59" x2="57.15" y2="24.765" width="0.254" layer="1"/>
+<wire x1="18.288" y1="38.608" x2="18.288" y2="22.352" width="0.254" layer="1"/>
+<wire x1="36.83" y1="24.765" x2="36.83" y2="22.86" width="0.254" layer="1"/>
+<wire x1="36.83" y1="22.86" x2="38.1" y2="21.59" width="0.254" layer="1"/>
+<wire x1="38.1" y1="21.59" x2="38.1" y2="20.32" width="0.254" layer="1"/>
+<wire x1="39.37" y1="24.765" x2="39.37" y2="22.86" width="0.254" layer="1"/>
+<wire x1="39.37" y1="22.86" x2="38.1" y2="21.59" width="0.254" layer="1"/>
 </signal>
 <signal name="N$27">
 <contactref element="SW07" pad="MX2"/>
 <contactref element="D7" pad="A"/>
-<wire x1="67.945" y1="57.15" x2="69.215" y2="55.88" width="0.254" layer="1"/>
-<wire x1="69.215" y1="55.88" x2="69.215" y2="52.705" width="0.254" layer="1"/>
-<wire x1="66.23" y1="57.15" x2="67.945" y2="57.15" width="0.254" layer="1"/>
+<wire x1="69.215" y1="52.705" x2="58.42" y2="52.705" width="0.254" layer="1"/>
+<wire x1="58.42" y1="52.705" x2="57.15" y2="51.435" width="0.254" layer="1"/>
 </signal>
 <signal name="N$30">
 <contactref element="SW08" pad="MX2"/>
 <contactref element="D8" pad="A"/>
-<wire x1="50.165" y1="55.309" x2="50.165" y2="52.705" width="0.254" layer="1"/>
+<wire x1="50.165" y1="52.705" x2="40.64" y2="52.705" width="0.254" layer="1"/>
+<wire x1="40.64" y1="52.705" x2="39.37" y2="51.435" width="0.254" layer="1"/>
 </signal>
 <signal name="N$32">
-<contactref element="D8" pad="C"/>
-<contactref element="D9" pad="C"/>
-<contactref element="D7" pad="C"/>
 <contactref element="U$1" pad="27"/>
 <wire x1="12.2613625" y1="40.096196875" x2="13.363965625" y2="41.1988" width="0.254" layer="1"/>
-<wire x1="16.256" y1="41.1988" x2="17.78" y2="42.7228" width="0.254" layer="1"/>
-<wire x1="13.363965625" y1="41.1988" x2="16.256" y2="41.1988" width="0.254" layer="1"/>
-<wire x1="50.165" y1="57.15" x2="49.784" y2="57.15" width="0.254" layer="1"/>
-<wire x1="49.784" y1="57.15" x2="31.496" y2="57.15" width="0.254" layer="1"/>
-<wire x1="31.496" y1="57.15" x2="31.115" y2="57.15" width="0.254" layer="1"/>
-<wire x1="31.115" y1="57.15" x2="30.734" y2="57.15" width="0.254" layer="1"/>
-<wire x1="31.115" y1="55.689" x2="31.115" y2="56.769" width="0.254" layer="1"/>
-<wire x1="31.115" y1="56.769" x2="31.115" y2="57.15" width="0.254" layer="1"/>
-<wire x1="50.165" y1="55.689" x2="50.165" y2="56.769" width="0.254" layer="1"/>
-<wire x1="50.165" y1="56.769" x2="50.165" y2="57.15" width="0.254" layer="1"/>
-<wire x1="65.85" y1="57.15" x2="50.546" y2="57.15" width="0.254" layer="1"/>
-<wire x1="50.546" y1="57.15" x2="50.165" y2="57.15" width="0.254" layer="1"/>
-<wire x1="30.734" y1="57.15" x2="31.115" y2="56.769" width="0.254" layer="1"/>
-<wire x1="31.496" y1="57.15" x2="31.115" y2="56.769" width="0.254" layer="1"/>
-<wire x1="49.784" y1="57.15" x2="50.165" y2="56.769" width="0.254" layer="1"/>
-<wire x1="50.546" y1="57.15" x2="50.165" y2="56.769" width="0.254" layer="1"/>
-<wire x1="17.78" y1="55.88" x2="19.05" y2="57.15" width="0.254" layer="1"/>
-<wire x1="17.78" y1="42.7228" x2="17.78" y2="55.88" width="0.254" layer="1"/>
-<wire x1="19.05" y1="57.15" x2="30.734" y2="57.15" width="0.254" layer="1"/>
+<contactref element="D9" pad="C"/>
+<contactref element="D8" pad="C"/>
+<contactref element="D7" pad="C"/>
+<wire x1="19.7612" y1="41.1988" x2="21.59" y2="39.37" width="0.254" layer="1"/>
+<wire x1="21.59" y1="39.37" x2="38.1" y2="39.37" width="0.254" layer="1"/>
+<wire x1="38.1" y1="39.37" x2="55.88" y2="39.37" width="0.254" layer="1"/>
+<wire x1="55.88" y1="39.37" x2="57.15" y2="40.64" width="0.254" layer="1"/>
+<wire x1="57.15" y1="40.64" x2="57.15" y2="43.815" width="0.254" layer="1"/>
+<wire x1="13.363965625" y1="41.1988" x2="19.7612" y2="41.1988" width="0.254" layer="1"/>
+<wire x1="36.83" y1="43.815" x2="36.83" y2="41.91" width="0.254" layer="1"/>
+<wire x1="36.83" y1="41.91" x2="38.1" y2="40.64" width="0.254" layer="1"/>
+<wire x1="38.1" y1="40.64" x2="39.37" y2="41.91" width="0.254" layer="1"/>
+<wire x1="39.37" y1="41.91" x2="39.37" y2="43.815" width="0.254" layer="1"/>
+<wire x1="38.1" y1="40.64" x2="38.1" y2="39.37" width="0.254" layer="1"/>
 </signal>
 <signal name="N$33">
 <contactref element="SW09" pad="MX2"/>
 <contactref element="D9" pad="A"/>
-<wire x1="31.115" y1="55.309" x2="31.115" y2="52.705" width="0.254" layer="1"/>
+<wire x1="31.115" y1="52.705" x2="35.56" y2="52.705" width="0.254" layer="1"/>
+<wire x1="35.56" y1="52.705" x2="36.83" y2="51.435" width="0.254" layer="1"/>
 </signal>
 <signal name="N$36">
 <contactref element="SW10" pad="MX2"/>
-<contactref element="D10" pad="A"/>
 <wire x1="69.215" y1="71.755" x2="58.4696" y2="71.755" width="0.254" layer="1"/>
 <wire x1="57.15" y1="70.4354" x2="58.4696" y2="71.755" width="0.254" layer="1"/>
-<wire x1="57.15" y1="68.77" x2="57.15" y2="70.4354" width="0.254" layer="1"/>
+<contactref element="D10" pad="A"/>
+<wire x1="57.15" y1="70.485" x2="57.15" y2="70.4354" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$38">
+<contactref element="U$1" pad="28"/>
+<wire x1="11.910284375" y1="40.4522125" x2="13.114071875" y2="41.656" width="0.254" layer="1"/>
+<wire x1="17.526" y1="41.656" x2="19.177" y2="43.307" width="0.254" layer="1"/>
+<wire x1="13.114071875" y1="41.656" x2="17.526" y2="41.656" width="0.254" layer="1"/>
+<wire x1="55.88" y1="58.42" x2="57.15" y2="59.69" width="0.254" layer="1"/>
+<wire x1="19.177" y1="43.307" x2="19.177" y2="57.023" width="0.254" layer="1"/>
+<wire x1="19.177" y1="57.023" x2="20.574" y2="58.42" width="0.254" layer="1"/>
 <contactref element="D10" pad="C"/>
 <contactref element="D11" pad="C"/>
 <contactref element="D12" pad="C"/>
-<contactref element="U$1" pad="28"/>
-<wire x1="11.910284375" y1="40.4522125" x2="13.114071875" y2="41.656" width="0.254" layer="1"/>
-<wire x1="16.002" y1="41.656" x2="17.272" y2="42.926" width="0.254" layer="1"/>
-<wire x1="13.114071875" y1="41.656" x2="16.002" y2="41.656" width="0.254" layer="1"/>
-<wire x1="36.83" y1="68.39" x2="36.83" y2="66.04" width="0.254" layer="1"/>
-<wire x1="39.37" y1="68.39" x2="39.37" y2="66.04" width="0.254" layer="1"/>
-<wire x1="36.83" y1="66.04" x2="37.846" y2="65.024" width="0.254" layer="1"/>
-<wire x1="39.37" y1="66.04" x2="38.354" y2="65.024" width="0.254" layer="1"/>
-<wire x1="38.1" y1="64.77" x2="37.846" y2="65.024" width="0.254" layer="1"/>
-<wire x1="38.1" y1="64.77" x2="38.354" y2="65.024" width="0.254" layer="1"/>
-<wire x1="37.846" y1="65.024" x2="38.354" y2="65.024" width="0.254" layer="1"/>
-<wire x1="55.88" y1="58.42" x2="57.15" y2="59.69" width="0.254" layer="1"/>
-<wire x1="38.1" y1="64.77" x2="38.1" y2="58.801" width="0.254" layer="1"/>
-<wire x1="38.1" y1="58.801" x2="38.1" y2="58.42" width="0.254" layer="1"/>
-<wire x1="55.88" y1="58.42" x2="38.481" y2="58.42" width="0.254" layer="1"/>
-<wire x1="38.481" y1="58.42" x2="38.1" y2="58.42" width="0.254" layer="1"/>
-<wire x1="57.15" y1="59.69" x2="57.15" y2="68.39" width="0.254" layer="1"/>
-<wire x1="37.719" y1="58.42" x2="38.1" y2="58.42" width="0.254" layer="1"/>
-<wire x1="38.481" y1="58.42" x2="38.1" y2="58.801" width="0.254" layer="1"/>
-<wire x1="37.719" y1="58.42" x2="38.1" y2="58.801" width="0.254" layer="1"/>
-<wire x1="17.272" y1="42.926" x2="17.272" y2="56.134" width="0.254" layer="1"/>
-<wire x1="17.272" y1="56.134" x2="19.558" y2="58.42" width="0.254" layer="1"/>
-<wire x1="19.558" y1="58.42" x2="37.719" y2="58.42" width="0.254" layer="1"/>
+<wire x1="38.1" y1="58.42" x2="55.88" y2="58.42" width="0.254" layer="1"/>
+<wire x1="57.15" y1="59.69" x2="57.15" y2="62.865" width="0.254" layer="1"/>
+<wire x1="36.83" y1="62.865" x2="36.83" y2="60.96" width="0.254" layer="1"/>
+<wire x1="36.83" y1="60.96" x2="38.1" y2="59.69" width="0.254" layer="1"/>
+<wire x1="39.37" y1="62.865" x2="39.37" y2="60.96" width="0.254" layer="1"/>
+<wire x1="39.37" y1="60.96" x2="38.1" y2="59.69" width="0.254" layer="1"/>
+<wire x1="38.1" y1="59.69" x2="38.1" y2="58.42" width="0.254" layer="1"/>
+<wire x1="20.574" y1="58.42" x2="38.1" y2="58.42" width="0.254" layer="1"/>
 </signal>
 <signal name="N$39">
 <contactref element="SW11" pad="MX2"/>
-<contactref element="D11" pad="A"/>
-<wire x1="39.37" y1="68.77" x2="39.37" y2="70.358" width="0.254" layer="1"/>
 <wire x1="39.37" y1="70.358" x2="40.767" y2="71.755" width="0.254" layer="1"/>
 <wire x1="40.767" y1="71.755" x2="50.165" y2="71.755" width="0.254" layer="1"/>
+<contactref element="D11" pad="A"/>
+<wire x1="39.37" y1="70.485" x2="39.37" y2="70.358" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$40">
 <contactref element="SW11" pad="MX1"/>
@@ -1299,9 +1278,7 @@ design rules under a new name.</description>
 <contactref element="SW05" pad="MX1"/>
 <contactref element="SW08" pad="MX1"/>
 <contactref element="U$1" pad="30"/>
-<wire x1="11.20813125" y1="41.1642375" x2="14.51369375" y2="44.4698" width="0.254" layer="1"/>
-<wire x1="14.51369375" y1="44.4698" x2="15.24" y2="44.4698" width="0.254" layer="1"/>
-<via x="15.24" y="44.4698" extent="1-16" drill="0.3048"/>
+<wire x1="11.20813125" y1="41.1642375" x2="12.84289375" y2="42.799" width="0.254" layer="1"/>
 <wire x1="43.815" y1="69.215" x2="43.815" y2="68.043925" width="0.254" layer="16"/>
 <wire x1="43.815" y1="68.043925" x2="44.411" y2="67.447925" width="0.254" layer="16"/>
 <wire x1="44.411" y1="67.447925" x2="44.411" y2="65.902075" width="0.254" layer="16"/>
@@ -1317,20 +1294,20 @@ design rules under a new name.</description>
 <wire x1="44.411" y1="29.347925" x2="44.411" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="44.411" y1="27.802075" x2="43.815" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="43.815" y1="27.206075" x2="43.815" y2="12.065" width="0.254" layer="16"/>
-<wire x1="15.24" y1="44.4698" x2="19.05" y2="44.4698" width="0.254" layer="16"/>
-<via x="19.05" y="44.4698" extent="1-16" drill="0.35"/>
-<wire x1="19.05" y1="44.4698" x2="36.83" y2="44.4698" width="0.254" layer="1"/>
-<wire x1="36.83" y1="44.4698" x2="38.1" y2="45.7398" width="0.254" layer="1"/>
-<wire x1="38.1" y1="45.7398" x2="38.1" y2="48.895" width="0.254" layer="1"/>
-<wire x1="38.1" y1="48.895" x2="39.37" y2="50.165" width="0.254" layer="1"/>
-<wire x1="39.37" y1="50.165" x2="43.815" y2="50.165" width="0.254" layer="1"/>
+<wire x1="12.84289375" y1="42.799" x2="16.891" y2="42.799" width="0.254" layer="1"/>
+<wire x1="18.0086" y1="72.0503375" x2="20.2786625" y2="74.3204" width="0.254" layer="1"/>
+<via x="43.815" y="74.3176" extent="1-16" drill="0.35"/>
+<wire x1="43.815" y1="74.3176" x2="43.815" y2="69.215" width="0.254" layer="16"/>
+<wire x1="16.891" y1="42.799" x2="18.0086" y2="43.9166" width="0.254" layer="1"/>
+<wire x1="18.0086" y1="43.9166" x2="18.0086" y2="72.0503375" width="0.254" layer="1"/>
+<wire x1="20.2786625" y1="74.3204" x2="43.8122" y2="74.3204" width="0.254" layer="1"/>
+<wire x1="43.8122" y1="74.3204" x2="43.815" y2="74.3176" width="0.254" layer="1"/>
 </signal>
 <signal name="N$42">
 <contactref element="SW12" pad="MX2"/>
 <contactref element="D12" pad="A"/>
-<wire x1="36.83" y1="68.77" x2="36.83" y2="70.358" width="0.254" layer="1"/>
-<wire x1="36.83" y1="70.358" x2="35.433" y2="71.755" width="0.254" layer="1"/>
-<wire x1="35.433" y1="71.755" x2="31.115" y2="71.755" width="0.254" layer="1"/>
+<wire x1="31.115" y1="71.755" x2="35.56" y2="71.755" width="0.254" layer="1"/>
+<wire x1="35.56" y1="71.755" x2="36.83" y2="70.485" width="0.254" layer="1"/>
 </signal>
 <signal name="N$4">
 <contactref element="U$1" pad="33"/>
@@ -1588,4 +1565,21 @@ design rules under a new name.</description>
 </errors>
 </board>
 </drawing>
+<compatibility>
+<note version="8.2" severity="warning">
+Since Version 8.2, EAGLE supports online libraries. The ids
+of those online libraries will not be understood (or retained)
+with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports URNs for individual library
+assets (packages, symbols, and devices). The URNs of those assets
+will not be understood (or retained) with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports the association of 3D packages
+with devices in libraries, schematics, and board files. Those 3D
+packages will not be understood (or retained) with this version.
+</note>
+</compatibility>
 </eagle>

--- a/PCB/MacroPad.brd
+++ b/PCB/MacroPad.brd
@@ -154,6 +154,7 @@
 <wire x1="76.2" y1="76.2" x2="0" y2="76.19" width="0" layer="20"/>
 <wire x1="0" y1="76.19" x2="0" y2="0" width="0" layer="20"/>
 <text x="38.1" y="2.54" size="1.778" layer="22" rot="MR0" align="bottom-center">v20190525</text>
+<text x="9.525" y="38.1" size="1.778" layer="25" align="center">⬅</text>
 </plain>
 <libraries>
 <library name="Components">

--- a/PCB/MacroPad.brd
+++ b/PCB/MacroPad.brd
@@ -1268,15 +1268,14 @@ design rules under a new name.</description>
 <wire x1="63.461" y1="29.347925" x2="63.461" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="63.461" y1="27.802075" x2="62.865" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="62.865" y1="27.206075" x2="62.865" y2="12.065" width="0.254" layer="16"/>
-<wire x1="18.542" y1="71.374" x2="20.828" y2="73.66" width="0.254" layer="1"/>
-<wire x1="20.828" y1="73.66" x2="60.96" y2="73.66" width="0.254" layer="1"/>
-<via x="60.96" y="73.66" extent="1-16" drill="0.3048"/>
-<wire x1="60.96" y1="73.66" x2="62.865" y2="71.755" width="0.254" layer="16"/>
-<wire x1="62.865" y1="71.755" x2="62.865" y2="69.215" width="0.254" layer="16"/>
-<wire x1="18.542" y1="48.26" x2="18.542" y2="71.374" width="0.254" layer="1"/>
-<contactref element="U1" pad="29"/>
-<wire x1="13.027296875" y1="42.71585" x2="13.027296875" y2="42.745296875" width="0.254" layer="1"/>
-<wire x1="13.027296875" y1="42.745296875" x2="18.542" y2="48.26" width="0.254" layer="1"/>
+<contactref element="U1" pad="31"/>
+<wire x1="16.891" y1="48.842575" x2="11.8957875" y2="43.8473625" width="0.254" layer="1"/>
+<wire x1="16.891" y1="68.58" x2="21.971" y2="73.66" width="0.254" layer="1"/>
+<wire x1="21.971" y1="73.66" x2="51.562" y2="73.66" width="0.254" layer="1"/>
+<wire x1="62.191" y1="68.541" x2="62.865" y2="69.215" width="0.254" layer="1"/>
+<wire x1="56.681" y1="68.541" x2="62.191" y2="68.541" width="0.254" layer="1"/>
+<wire x1="16.891" y1="48.842575" x2="16.891" y2="68.58" width="0.254" layer="1"/>
+<wire x1="51.562" y1="73.66" x2="56.681" y2="68.541" width="0.254" layer="1"/>
 </signal>
 <signal name="N$12">
 <contactref element="SW02" pad="MX2"/>
@@ -1285,7 +1284,7 @@ design rules under a new name.</description>
 <wire x1="40.64" y1="14.605" x2="39.37" y2="13.335" width="0.254" layer="1"/>
 </signal>
 <signal name="N$14">
-<wire x1="18.034" y1="42.164" x2="18.923" y2="41.275" width="0.254" layer="1"/>
+<wire x1="18.161" y1="42.418" x2="18.923" y2="41.656" width="0.254" layer="1"/>
 <contactref element="D1" pad="C"/>
 <contactref element="D2" pad="C"/>
 <contactref element="D3" pad="C"/>
@@ -1294,15 +1293,15 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="1.27" x2="55.88" y2="1.27" width="0.254" layer="1"/>
 <wire x1="55.88" y1="1.27" x2="57.15" y2="2.54" width="0.254" layer="1"/>
 <wire x1="57.15" y1="2.54" x2="57.15" y2="5.715" width="0.254" layer="1"/>
-<wire x1="18.923" y1="41.275" x2="18.923" y2="2.667" width="0.254" layer="1"/>
+<wire x1="18.923" y1="41.656" x2="18.923" y2="2.667" width="0.254" layer="1"/>
 <wire x1="36.83" y1="5.715" x2="36.83" y2="3.81" width="0.254" layer="1"/>
 <wire x1="36.83" y1="3.81" x2="38.1" y2="2.54" width="0.254" layer="1"/>
 <wire x1="38.1" y1="2.54" x2="39.37" y2="3.81" width="0.254" layer="1"/>
 <wire x1="39.37" y1="3.81" x2="39.37" y2="5.715" width="0.254" layer="1"/>
 <wire x1="38.1" y1="2.54" x2="38.1" y2="1.27" width="0.254" layer="1"/>
 <contactref element="U1" pad="25"/>
-<wire x1="15.2723625" y1="40.4707875" x2="16.965575" y2="42.164" width="0.254" layer="1"/>
-<wire x1="16.965575" y1="42.164" x2="18.034" y2="42.164" width="0.254" layer="1"/>
+<wire x1="15.2723625" y1="40.4707875" x2="17.219575" y2="42.418" width="0.254" layer="1"/>
+<wire x1="17.219575" y1="42.418" x2="18.161" y2="42.418" width="0.254" layer="1"/>
 </signal>
 <signal name="N$15">
 <contactref element="SW03" pad="MX2"/>
@@ -1330,13 +1329,11 @@ design rules under a new name.</description>
 <wire x1="25.361" y1="29.347925" x2="25.361" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="25.361" y1="27.802075" x2="24.765" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="24.765" y1="27.206075" x2="24.765" y2="12.065" width="0.254" layer="16"/>
-<wire x1="11.8957875" y1="43.8473625" x2="17.526" y2="49.477575" width="0.254" layer="1"/>
-<wire x1="17.526" y1="49.477575" x2="17.526" y2="72.771" width="0.254" layer="1"/>
-<wire x1="17.526" y1="72.771" x2="18.542" y2="73.787" width="0.254" layer="1"/>
-<via x="18.542" y="73.787" extent="1-16" drill="0.3048"/>
-<wire x1="18.542" y1="73.787" x2="23.114" y2="69.215" width="0.254" layer="16"/>
-<wire x1="23.114" y1="69.215" x2="24.765" y2="69.215" width="0.254" layer="16"/>
-<contactref element="U1" pad="31"/>
+<contactref element="U1" pad="29"/>
+<wire x1="13.027296875" y1="42.71585" x2="18.3896" y2="48.078153125" width="0.254" layer="1"/>
+<wire x1="18.3896" y1="67.9196" x2="19.685" y2="69.215" width="0.254" layer="1"/>
+<wire x1="19.685" y1="69.215" x2="24.765" y2="69.215" width="0.254" layer="1"/>
+<wire x1="18.3896" y1="48.078153125" x2="18.3896" y2="67.9196" width="0.254" layer="1"/>
 </signal>
 <signal name="N$18">
 <contactref element="SW04" pad="MX2"/>
@@ -1363,16 +1360,16 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="20.32" x2="55.88" y2="20.32" width="0.254" layer="1"/>
 <wire x1="55.88" y1="20.32" x2="57.15" y2="21.59" width="0.254" layer="1"/>
 <wire x1="57.15" y1="21.59" x2="57.15" y2="24.765" width="0.254" layer="1"/>
-<wire x1="19.558" y1="41.783" x2="19.558" y2="21.59" width="0.254" layer="1"/>
+<wire x1="19.558" y1="42.164" x2="19.558" y2="21.59" width="0.254" layer="1"/>
 <wire x1="36.83" y1="24.765" x2="36.83" y2="22.86" width="0.254" layer="1"/>
 <wire x1="36.83" y1="22.86" x2="38.1" y2="21.59" width="0.254" layer="1"/>
 <wire x1="38.1" y1="21.59" x2="38.1" y2="20.32" width="0.254" layer="1"/>
 <wire x1="39.37" y1="24.765" x2="39.37" y2="22.86" width="0.254" layer="1"/>
 <wire x1="39.37" y1="22.86" x2="38.1" y2="21.59" width="0.254" layer="1"/>
 <contactref element="U1" pad="26"/>
-<wire x1="18.3896" y1="42.9514" x2="16.639425" y2="42.9514" width="0.254" layer="1"/>
-<wire x1="16.639425" y1="42.9514" x2="14.7155875" y2="41.0275625" width="0.254" layer="1"/>
-<wire x1="19.558" y1="41.783" x2="18.3896" y2="42.9514" width="0.254" layer="1"/>
+<wire x1="18.5166" y1="43.2054" x2="16.893425" y2="43.2054" width="0.254" layer="1"/>
+<wire x1="16.893425" y1="43.2054" x2="14.7155875" y2="41.0275625" width="0.254" layer="1"/>
+<wire x1="19.558" y1="42.164" x2="18.5166" y2="43.2054" width="0.254" layer="1"/>
 <wire x1="19.558" y1="21.59" x2="20.828" y2="20.32" width="0.254" layer="1"/>
 <wire x1="20.828" y1="20.32" x2="38.1" y2="20.32" width="0.254" layer="1"/>
 </signal>
@@ -1392,7 +1389,7 @@ design rules under a new name.</description>
 <contactref element="D9" pad="C"/>
 <contactref element="D8" pad="C"/>
 <contactref element="D7" pad="C"/>
-<wire x1="23.114" y1="39.37" x2="38.1" y2="39.37" width="0.254" layer="1"/>
+<wire x1="23.368" y1="39.37" x2="38.1" y2="39.37" width="0.254" layer="1"/>
 <wire x1="38.1" y1="39.37" x2="55.88" y2="39.37" width="0.254" layer="1"/>
 <wire x1="55.88" y1="39.37" x2="57.15" y2="40.64" width="0.254" layer="1"/>
 <wire x1="57.15" y1="40.64" x2="57.15" y2="43.815" width="0.254" layer="1"/>
@@ -1403,8 +1400,8 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="40.64" x2="38.1" y2="39.37" width="0.254" layer="1"/>
 <contactref element="U1" pad="27"/>
 <wire x1="14.14085" y1="41.602296875" x2="16.480553125" y2="43.942" width="0.254" layer="1"/>
-<wire x1="16.480553125" y1="43.942" x2="18.542" y2="43.942" width="0.254" layer="1"/>
-<wire x1="18.542" y1="43.942" x2="23.114" y2="39.37" width="0.254" layer="1"/>
+<wire x1="16.480553125" y1="43.942" x2="18.796" y2="43.942" width="0.254" layer="1"/>
+<wire x1="18.796" y1="43.942" x2="23.368" y2="39.37" width="0.254" layer="1"/>
 </signal>
 <signal name="N$33">
 <contactref element="SW09" pad="MX2"/>
@@ -1414,15 +1411,14 @@ design rules under a new name.</description>
 </signal>
 <signal name="N$36">
 <contactref element="SW10" pad="MX2"/>
-<wire x1="69.215" y1="71.755" x2="58.4696" y2="71.755" width="0.254" layer="1"/>
-<wire x1="57.15" y1="70.4354" x2="58.4696" y2="71.755" width="0.254" layer="1"/>
 <contactref element="D10" pad="A"/>
-<wire x1="57.15" y1="70.485" x2="57.15" y2="70.4354" width="0" layer="19" extent="1-1"/>
+<wire x1="58.42" y1="71.755" x2="57.15" y2="70.485" width="0.254" layer="1"/>
+<wire x1="69.215" y1="71.755" x2="58.42" y2="71.755" width="0.254" layer="1"/>
 </signal>
 <signal name="N$38">
 <wire x1="55.88" y1="58.42" x2="57.15" y2="59.69" width="0.254" layer="1"/>
-<wire x1="19.05" y1="47.625" x2="19.05" y2="56.896" width="0.254" layer="1"/>
-<wire x1="19.05" y1="56.896" x2="20.574" y2="58.42" width="0.254" layer="1"/>
+<wire x1="19.177" y1="47.752" x2="19.177" y2="57.023" width="0.254" layer="1"/>
+<wire x1="19.177" y1="57.023" x2="20.574" y2="58.42" width="0.254" layer="1"/>
 <contactref element="D10" pad="C"/>
 <contactref element="D11" pad="C"/>
 <contactref element="D12" pad="C"/>
@@ -1435,14 +1431,13 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="59.69" x2="38.1" y2="58.42" width="0.254" layer="1"/>
 <wire x1="20.574" y1="58.42" x2="38.1" y2="58.42" width="0.254" layer="1"/>
 <contactref element="U1" pad="28"/>
-<wire x1="13.584075" y1="42.159075" x2="19.05" y2="47.625" width="0.254" layer="1"/>
+<wire x1="13.584075" y1="42.159075" x2="19.177" y2="47.752" width="0.254" layer="1"/>
 </signal>
 <signal name="N$39">
 <contactref element="SW11" pad="MX2"/>
-<wire x1="39.37" y1="70.358" x2="40.767" y2="71.755" width="0.254" layer="1"/>
-<wire x1="40.767" y1="71.755" x2="50.165" y2="71.755" width="0.254" layer="1"/>
 <contactref element="D11" pad="A"/>
-<wire x1="39.37" y1="70.485" x2="39.37" y2="70.358" width="0" layer="19" extent="1-1"/>
+<wire x1="40.64" y1="71.755" x2="39.37" y2="70.485" width="0.254" layer="1"/>
+<wire x1="50.165" y1="71.755" x2="40.64" y2="71.755" width="0.254" layer="1"/>
 </signal>
 <signal name="N$40">
 <contactref element="SW11" pad="MX1"/>
@@ -1464,15 +1459,14 @@ design rules under a new name.</description>
 <wire x1="44.411" y1="29.347925" x2="44.411" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="44.411" y1="27.802075" x2="43.815" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="43.815" y1="27.206075" x2="43.815" y2="12.065" width="0.254" layer="16"/>
-<wire x1="18.0086" y1="72.0503375" x2="20.2786625" y2="74.3204" width="0.254" layer="1"/>
-<via x="43.815" y="74.3176" extent="1-16" drill="0.3048"/>
-<wire x1="43.815" y1="74.3176" x2="43.815" y2="69.215" width="0.254" layer="16"/>
-<wire x1="18.0086" y1="48.8696" x2="18.0086" y2="72.0503375" width="0.254" layer="1"/>
-<wire x1="20.2786625" y1="74.3204" x2="43.8122" y2="74.3204" width="0.254" layer="1"/>
-<wire x1="43.8122" y1="74.3204" x2="43.815" y2="74.3176" width="0.254" layer="1"/>
 <contactref element="U1" pad="30"/>
 <wire x1="12.4525625" y1="43.2905875" x2="12.4525625" y2="43.3135625" width="0.254" layer="1"/>
-<wire x1="12.4525625" y1="43.3135625" x2="18.0086" y2="48.8696" width="0.254" layer="1"/>
+<wire x1="17.653" y1="48.491025" x2="12.4525625" y2="43.2905875" width="0.254" layer="1"/>
+<wire x1="17.653" y1="48.491025" x2="17.653" y2="68.2657375" width="0.254" layer="1"/>
+<wire x1="17.653" y1="68.2657375" x2="20.4056625" y2="71.0184" width="0.254" layer="1"/>
+<wire x1="20.4056625" y1="71.0184" x2="28.87786875" y2="71.0184" width="0.254" layer="1"/>
+<wire x1="28.87786875" y1="71.0184" x2="30.68126875" y2="69.215" width="0.254" layer="1"/>
+<wire x1="30.68126875" y1="69.215" x2="43.815" y2="69.215" width="0.254" layer="1"/>
 </signal>
 <signal name="N$42">
 <contactref element="SW12" pad="MX2"/>
@@ -1702,6 +1696,18 @@ design rules under a new name.</description>
 <approved hash="1,20,f0e51e031faaf14c"/>
 <approved hash="1,20,70e81e0e1cb47252"/>
 <approved hash="1,20,f5ed020b0187f661"/>
+<approved hash="4,16,1574257d0b9a9df9"/>
+<approved hash="1,20,13fd021b049a157c"/>
+<approved hash="1,20,f5e30205026bf58d"/>
+<approved hash="1,20,126301050168120e"/>
+<approved hash="1,20,f2670101009af3fc"/>
+<approved hash="1,20,726c030a028073e6"/>
+<approved hash="1,20,8e3e035802828fe4"/>
+<approved hash="1,20,65dc0a3a0a8e6568"/>
+<approved hash="1,20,efeb080d089aef7c"/>
+<approved hash="1,20,727c011a018372e5"/>
+<approved hash="1,20,64e43a023bab654d"/>
+<approved hash="1,20,92e40396016a9018"/>
 </errors>
 </board>
 </drawing>

--- a/PCB/MacroPad.brd
+++ b/PCB/MacroPad.brd
@@ -830,37 +830,37 @@ design rules under a new name.</description>
 <attribute name="NAME" x="4.333" y="26.708" size="1" layer="25" ratio="13" rot="R270" align="top-center"/>
 <attribute name="OC_NEWARK" value="96M1143" x="5.08" y="26.67" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="C3" library="Components" package="C0603" value="4.7u" x="4.953" y="46.101" smashed="yes" rot="R225">
+<element name="C5" library="Components" package="C0603" value="4.7u" x="4.953" y="46.101" smashed="yes" rot="R225">
 <attribute name="MF" value="" x="4.953" y="46.101" size="1.778" layer="27" rot="R225" display="off"/>
 <attribute name="MPN" value="" x="4.953" y="46.101" size="1.778" layer="27" rot="R225" display="off"/>
 <attribute name="NAME" x="4.436253125" y="46.606115625" size="1" layer="25" ratio="13" rot="R225" align="top-center"/>
 <attribute name="OC_NEWARK" value="unknown" x="4.953" y="46.101" size="1.778" layer="27" rot="R225" display="off"/>
 </element>
-<element name="C4" library="Components" package="C0603" value="0.1u" x="6.35" y="34.925" smashed="yes" rot="MR45">
+<element name="C8" library="Components" package="C0603" value="0.1u" x="6.35" y="34.925" smashed="yes" rot="MR45">
 <attribute name="MF" value="" x="6.35" y="34.925" size="1.778" layer="28" rot="MR45" display="off"/>
 <attribute name="MPN" value="" x="6.35" y="34.925" size="1.778" layer="28" rot="MR45" display="off"/>
 <attribute name="NAME" x="6.867303125" y="35.45393125" size="1" layer="26" ratio="13" rot="MR45" align="bottom-center"/>
 <attribute name="OC_NEWARK" value="unknown" x="6.35" y="34.925" size="1.778" layer="28" rot="MR45" display="off"/>
 </element>
-<element name="C5" library="Components" package="C0603" value="0.1u" x="3.81" y="38.735" smashed="yes" rot="MR135">
+<element name="C9" library="Components" package="C0603" value="0.1u" x="3.81" y="38.735" smashed="yes" rot="MR135">
 <attribute name="MF" value="" x="3.81" y="38.735" size="1.778" layer="28" rot="MR135" display="off"/>
 <attribute name="MPN" value="" x="3.81" y="38.735" size="1.778" layer="28" rot="MR135" display="off"/>
 <attribute name="NAME" x="4.33893125" y="38.217690625" size="1" layer="26" ratio="13" rot="MR135" align="bottom-center"/>
 <attribute name="OC_NEWARK" value="unknown" x="3.81" y="38.735" size="1.778" layer="28" rot="MR135" display="off"/>
 </element>
-<element name="C6" library="Components" package="C0603" value="0.1u" x="11.557" y="33.909" smashed="yes" rot="MR135">
+<element name="C7" library="Components" package="C0603" value="0.1u" x="11.557" y="33.909" smashed="yes" rot="MR135">
 <attribute name="MF" value="" x="11.557" y="33.909" size="1.778" layer="28" rot="MR135" display="off"/>
 <attribute name="MPN" value="" x="11.557" y="33.909" size="1.778" layer="28" rot="MR135" display="off"/>
 <attribute name="NAME" x="11.06993125" y="34.28069375" size="1" layer="26" ratio="13" rot="MR135" align="top-center"/>
 <attribute name="OC_NEWARK" value="unknown" x="11.557" y="33.909" size="1.778" layer="28" rot="MR135" display="off"/>
 </element>
-<element name="C7" library="Components" package="C0603" value="0.1u" x="14.986" y="38.481" smashed="yes" rot="MR225">
+<element name="C6" library="Components" package="C0603" value="0.1u" x="14.986" y="38.481" smashed="yes" rot="MR225">
 <attribute name="MF" value="" x="14.986" y="38.481" size="1.778" layer="28" rot="MR225" display="off"/>
 <attribute name="MPN" value="" x="14.986" y="38.481" size="1.778" layer="28" rot="MR225" display="off"/>
 <attribute name="NAME" x="14.46869375" y="37.952065625" size="1" layer="26" ratio="13" rot="MR225" align="bottom-center"/>
 <attribute name="OC_NEWARK" value="unknown" x="14.986" y="38.481" size="1.778" layer="28" rot="MR225" display="off"/>
 </element>
-<element name="C8" library="Components" package="C0603" value="1u" x="3.556" y="30.48" smashed="yes" rot="R270">
+<element name="C3" library="Components" package="C0603" value="1u" x="3.556" y="30.48" smashed="yes" rot="R270">
 <attribute name="MF" value="" x="3.556" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="MPN" value="" x="3.556" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="NAME" x="4.206" y="30.391" size="1" layer="25" ratio="13" rot="R270" align="bottom-center"/>
@@ -897,7 +897,7 @@ design rules under a new name.</description>
 <attribute name="NAME" x="7.127" y="52.108" size="1" layer="25" ratio="13" rot="R270" align="top-center"/>
 <attribute name="OC_NEWARK" value="unknown" x="7.874" y="52.07" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="SW00" library="Hardware" package="SWITCH-SMD-EVQP-P2602W" value="SWITCH-SMD-EVQP-P2602W" x="9.525" y="9.398" smashed="yes">
+<element name="RESET" library="Hardware" package="SWITCH-SMD-EVQP-P2602W" value="SWITCH-SMD-EVQP-P2602W" x="9.525" y="9.398" smashed="yes">
 <attribute name="MF" value="" x="9.525" y="9.398" size="1.778" layer="27" display="off"/>
 <attribute name="MPN" value="" x="9.525" y="9.398" size="1.778" layer="27" display="off"/>
 <attribute name="NAME" x="9.525" y="6.198" size="1.27" layer="21" font="vector" align="bottom-center"/>
@@ -981,7 +981,7 @@ design rules under a new name.</description>
 <attribute name="OC_NEWARK" value="unknown" x="9.525" y="76.2" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="VALUE" x="3.81" y="74.93" size="1.27" layer="27" rot="R270"/>
 </element>
-<element name="C9" library="Components" package="C0603" value="0.1u" x="5.969" y="45.085" smashed="yes" rot="R226">
+<element name="C4" library="Components" package="C0603" value="0.1u" x="5.969" y="45.085" smashed="yes" rot="R226">
 <attribute name="MF" value="" x="5.969" y="45.085" size="1.778" layer="27" rot="R226" display="off"/>
 <attribute name="MPN" value="" x="5.969" y="45.085" size="1.778" layer="27" rot="R226" display="off"/>
 <attribute name="NAME" x="4.83329375" y="43.811940625" size="1" layer="25" ratio="13" rot="R226" align="center-left"/>
@@ -1077,11 +1077,11 @@ design rules under a new name.</description>
 <wire x1="11.709" y1="27.686" x2="14.224" y2="27.686" width="0.254" layer="1"/>
 </signal>
 <signal name="VCC">
-<contactref element="C3" pad="1"/>
-<contactref element="C4" pad="1"/>
 <contactref element="C5" pad="1"/>
-<contactref element="C6" pad="1"/>
+<contactref element="C8" pad="1"/>
+<contactref element="C9" pad="1"/>
 <contactref element="C7" pad="1"/>
+<contactref element="C6" pad="1"/>
 <contactref element="R1" pad="1"/>
 <contactref element="USB1" pad="VCC"/>
 <wire x1="15.192784375" y1="39.925215625" x2="14.367284375" y2="39.099715625" width="0.254" layer="16"/>
@@ -1090,7 +1090,7 @@ design rules under a new name.</description>
 <wire x1="2.175284375" y1="43.925715625" x2="2.175284375" y2="39.13228125" width="0.254" layer="16"/>
 <wire x1="2.175284375" y1="39.13228125" x2="3.191284375" y2="38.11628125" width="0.254" layer="16"/>
 <wire x1="11.125" y1="48.26" x2="11.125" y2="67.55" width="0.508" layer="1"/>
-<contactref element="C9" pad="1"/>
+<contactref element="C4" pad="1"/>
 <wire x1="7.5940625" y1="47.608715625" x2="7.577778125" y2="47.625" width="0.508" layer="1"/>
 <wire x1="6.460715625" y1="47.608715625" x2="5.571715625" y2="46.719715625" width="0.508" layer="1"/>
 <via x="11.125" y="47.625" extent="1-16" drill="0.3048"/>
@@ -1178,8 +1178,8 @@ design rules under a new name.</description>
 <wire x1="9.57221875" y1="33.702215625" x2="10.112784375" y2="34.24278125" width="0.508" layer="16"/>
 </signal>
 <signal name="N$3">
-<contactref element="SW00" pad="2A"/>
-<contactref element="SW00" pad="2B"/>
+<contactref element="RESET" pad="2A"/>
+<contactref element="RESET" pad="2B"/>
 <wire x1="12.095" y1="10.398" x2="6.955" y2="10.398" width="0.254" layer="1"/>
 <wire x1="6.955" y1="10.398" x2="6.955" y2="12.402" width="0.254" layer="1"/>
 <contactref element="U1" pad="13"/>
@@ -1195,7 +1195,7 @@ design rules under a new name.</description>
 <wire x1="8.509" y1="17.145" x2="8.509" y2="13.984" width="0.254" layer="1"/>
 </signal>
 <signal name="UCAP">
-<contactref element="C8" pad="1"/>
+<contactref element="C3" pad="1"/>
 <wire x1="3.556" y1="32.131" x2="3.556" y2="31.355" width="0.254" layer="1"/>
 <contactref element="U1" pad="6"/>
 <wire x1="5.465921875" y1="34.040921875" x2="3.556" y2="32.131" width="0.254" layer="1"/>
@@ -1501,20 +1501,20 @@ design rules under a new name.</description>
 <signal name="GND">
 <contactref element="F1" pad="1"/>
 <contactref element="USB1" pad="GND"/>
-<contactref element="C8" pad="2"/>
-<via x="7.874" y="65.151" extent="1-16" drill="0.3048"/>
 <contactref element="C3" pad="2"/>
-<contactref element="C4" pad="2"/>
+<via x="7.874" y="65.151" extent="1-16" drill="0.3048"/>
 <contactref element="C5" pad="2"/>
-<contactref element="C6" pad="2"/>
-<contactref element="C7" pad="2"/>
+<contactref element="C8" pad="2"/>
 <contactref element="C9" pad="2"/>
+<contactref element="C7" pad="2"/>
+<contactref element="C6" pad="2"/>
+<contactref element="C4" pad="2"/>
 <wire x1="12.17571875" y1="34.527715625" x2="12.17571875" y2="34.17928125" width="0.254" layer="16"/>
 <wire x1="4.33428125" y1="45.48228125" x2="4.33428125" y2="45.042165625" width="0.254" layer="1"/>
 <contactref element="C1" pad="1"/>
 <contactref element="C2" pad="1"/>
-<contactref element="SW00" pad="1A"/>
-<contactref element="SW00" pad="1B"/>
+<contactref element="RESET" pad="1A"/>
+<contactref element="RESET" pad="1B"/>
 <contactref element="R2" pad="1"/>
 <wire x1="5.08" y1="27.545" x2="5.13" y2="27.595" width="0.254" layer="1"/>
 <wire x1="13.335" y1="63.008" x2="13.335" y2="61.341" width="0.254" layer="1"/>

--- a/PCB/MacroPad.brd
+++ b/PCB/MacroPad.brd
@@ -385,7 +385,7 @@
 </package3d>
 </packages3d>
 </library>
-<library name="ATMEGA32U4-AUR">
+<library name="ATMEGA32U4-AU">
 <packages>
 <package name="QFP80P1200X1200X120-44N">
 <wire x1="-4.572" y1="5.0546" x2="-5.0546" y2="5.0546" width="0.1524" layer="21"/>
@@ -577,8 +577,8 @@
 <wire x1="5.0546" y1="-5.0546" x2="5.0546" y2="5.0546" width="0" layer="51"/>
 <wire x1="5.0546" y1="5.0546" x2="-5.0546" y2="5.0546" width="0" layer="51"/>
 <wire x1="-5.0546" y1="5.0546" x2="-5.0546" y2="-5.0546" width="0" layer="51"/>
-<text x="-4.17045" y="-10.0955" size="2.08521875" layer="25" ratio="10" rot="SR0">&gt;NAME</text>
-<text x="-3.46611875" y="10.118" size="2.089859375" layer="27" ratio="10" rot="SR0">&gt;VALUE</text>
+<text x="-4.16611875" y="-10.0851" size="2.083059375" layer="25" ratio="10" rot="SR0">&gt;NAME</text>
+<text x="-3.45928125" y="10.098" size="2.085740625" layer="27" ratio="10" rot="SR0">&gt;VALUE</text>
 <smd name="1" x="-5.7404" y="3.9878" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
 <smd name="2" x="-5.7404" y="3.2004" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
 <smd name="3" x="-5.7404" y="2.3876" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
@@ -1024,46 +1024,46 @@ design rules under a new name.</description>
 <element name="D11" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="39.37" y="66.675" smashed="yes" rot="R270">
 <attribute name="VALUE" x="39.116" y="68.707" size="0.6096" layer="21" rot="R270"/>
 </element>
-<element name="U1" library="ATMEGA32U4-AUR" package="QFP80P1200X1200X120-44N" value="ATMEGA32U4-AUR" x="9.525" y="38.1" smashed="yes" rot="R45">
-<attribute name="AVAILABILITY" value="Unavailable" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
-<attribute name="DESCRIPTION" value=" ATmega Series 16 MHz 32 KB Flash 2.5 KB SRAM 8-Bit Microcontroller - TQFP-44 " x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
-<attribute name="MF" value="Microchip" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
-<attribute name="MP" value="ATMEGA32U4-AUR" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
-<attribute name="PACKAGE" value="TQFP-44 Microchip" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
-<attribute name="PRICE" value="None" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
-</element>
 <element name="Y1" library="Controller" package="CRYSTAL-3.2X5" value="" x="9.525" y="26.67" smashed="yes" rot="R180">
 <attribute name="NAME" x="9.525" y="24.42" size="1.27" layer="21" font="vector" rot="R180" align="bottom-center"/>
 <attribute name="VALUE" x="9.525" y="28.92" size="1.27" layer="21" font="vector" rot="R180" align="top-center"/>
+</element>
+<element name="U1" library="ATMEGA32U4-AU" package="QFP80P1200X1200X120-44N" value="ATMEGA32U4-AU" x="9.525" y="38.1" smashed="yes" rot="R45">
+<attribute name="AVAILABILITY" value="Unavailable" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
+<attribute name="DESCRIPTION" value=" MCU 8-bit ATmega AVR RISC 32KB Flash 3.3V/5V 44-Pin TQFP " x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
+<attribute name="MF" value="Microchip" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
+<attribute name="MP" value="ATMEGA32U4-AU" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
+<attribute name="PACKAGE" value="TQFP-44 Microchip" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
+<attribute name="PRICE" value="None" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
 </element>
 </elements>
 <signals>
 <signal name="N$1">
 <contactref element="C2" pad="2"/>
-<contactref element="U1" pad="16"/>
-<wire x1="13.027296875" y1="33.484146875" x2="14.859" y2="31.65244375" width="0.254" layer="1"/>
 <contactref element="Y1" pad="3"/>
 <wire x1="7.525" y1="25.47" x2="7.2" y2="25.795" width="0.254" layer="1"/>
 <wire x1="7.2" y1="25.795" x2="5.08" y2="25.795" width="0.254" layer="1"/>
-<wire x1="14.859" y1="31.65244375" x2="14.859" y2="30.55913125" width="0.254" layer="1"/>
+<wire x1="14.859" y1="30.55913125" x2="14.859" y2="31.65244375" width="0.254" layer="1"/>
 <wire x1="14.859" y1="30.55913125" x2="13.3936" y2="29.09373125" width="0.254" layer="1"/>
 <wire x1="7.525" y1="25.47" x2="8.89" y2="25.47" width="0.254" layer="1"/>
 <wire x1="8.89" y1="25.47" x2="9.525" y2="26.105" width="0.254" layer="1"/>
 <wire x1="9.525" y1="26.105" x2="9.525" y2="28.321" width="0.254" layer="1"/>
 <wire x1="9.525" y1="28.321" x2="10.29773125" y2="29.09373125" width="0.254" layer="1"/>
 <wire x1="10.29773125" y1="29.09373125" x2="13.3936" y2="29.09373125" width="0.254" layer="1"/>
+<contactref element="U1" pad="16"/>
+<wire x1="14.859" y1="31.65244375" x2="13.027296875" y2="33.484146875" width="0.254" layer="1"/>
 </signal>
 <signal name="N$2">
 <contactref element="C1" pad="2"/>
-<contactref element="U1" pad="17"/>
 <contactref element="Y1" pad="1"/>
-<wire x1="13.584075" y1="34.040921875" x2="15.494" y2="32.130996875" width="0.254" layer="1"/>
 <wire x1="15.494" y1="32.130996875" x2="15.494" y2="28.956" width="0.254" layer="1"/>
 <wire x1="15.494" y1="28.956" x2="14.224" y2="27.686" width="0.254" layer="1"/>
 <wire x1="14.224" y1="27.686" x2="14.083" y2="27.545" width="0.254" layer="1"/>
 <wire x1="14.083" y1="27.545" x2="13.97" y2="27.545" width="0.254" layer="1"/>
 <wire x1="11.525" y1="27.87" x2="11.709" y2="27.686" width="0.254" layer="1"/>
 <wire x1="11.709" y1="27.686" x2="14.224" y2="27.686" width="0.254" layer="1"/>
+<contactref element="U1" pad="17"/>
+<wire x1="13.584075" y1="34.040921875" x2="15.494" y2="32.130996875" width="0.254" layer="1"/>
 </signal>
 <signal name="VCC">
 <contactref element="C5" pad="1"/>
@@ -1099,7 +1099,7 @@ design rules under a new name.</description>
 <wire x1="6.576825" y1="45.714421875" x2="6.576825" y2="45.71460625" width="0.508" layer="1"/>
 <wire x1="6.576825" y1="45.71460625" x2="5.571715625" y2="46.719715625" width="0.508" layer="1"/>
 <via x="9.57221875" y="20.193" extent="1-16" drill="0.3048"/>
-<wire x1="9.57221875" y1="20.193" x2="9.57221875" y2="33.02" width="0.508" layer="16"/>
+<wire x1="9.57221875" y1="20.193" x2="9.57221875" y2="33.702215625" width="0.508" layer="16"/>
 <wire x1="9.57221875" y1="33.702215625" x2="9.57221875" y2="34.29" width="0.508" layer="16"/>
 <wire x1="9.57221875" y1="34.29" x2="9.57221875" y2="34.78335" width="0.508" layer="16"/>
 <wire x1="9.57221875" y1="20.193" x2="9.57221875" y2="18.923" width="0.508" layer="1"/>
@@ -1112,18 +1112,10 @@ design rules under a new name.</description>
 <wire x1="7.92121875" y1="35.25878125" x2="8.048221875" y2="35.385784375" width="0.508" layer="16"/>
 <wire x1="8.048221875" y1="35.385784375" x2="8.96978125" y2="35.385784375" width="0.508" layer="16"/>
 <wire x1="6.96871875" y1="34.30628125" x2="7.66721875" y2="35.00478125" width="0.508" layer="16"/>
-<contactref element="U1" pad="34"/>
-<contactref element="U1" pad="14"/>
-<contactref element="U1" pad="24"/>
-<contactref element="U1" pad="44"/>
-<contactref element="U1" pad="7"/>
-<contactref element="U1" pad="2"/>
 <wire x1="15.192784375" y1="39.925215625" x2="16.176215625" y2="39.925215625" width="0.254" layer="16"/>
 <wire x1="16.176215625" y1="39.925215625" x2="17.399" y2="41.148" width="0.254" layer="16"/>
 <via x="17.399" y="41.148" extent="1-16" drill="0.35"/>
-<wire x1="17.399" y1="41.148" x2="17.145" y2="41.148" width="0.254" layer="1"/>
-<wire x1="17.145" y1="41.148" x2="15.89305" y2="39.89605" width="0.254" layer="1"/>
-<wire x1="15.89305" y1="39.89605" x2="15.8471" y2="39.89605" width="0.254" layer="1"/>
+<wire x1="17.145" y1="41.148" x2="17.399" y2="41.148" width="0.254" layer="1"/>
 <wire x1="10.49" y1="47.625" x2="11.125" y2="48.26" width="0.508" layer="1"/>
 <wire x1="7.577778125" y1="47.625" x2="10.49" y2="47.625" width="0.508" layer="1"/>
 <wire x1="11.125" y1="47.625" x2="11.125" y2="48.26" width="0.508" layer="1"/>
@@ -1133,14 +1125,10 @@ design rules under a new name.</description>
 <wire x1="5.571715625" y1="46.719715625" x2="5.571715625" y2="47.117" width="0.508" layer="1"/>
 <wire x1="5.571715625" y1="47.117" x2="5.08" y2="47.608715625" width="0.508" layer="1"/>
 <wire x1="6.576825" y1="45.714421875" x2="7.550175" y2="45.714421875" width="0.3048" layer="1"/>
-<wire x1="7.550175" y1="45.714421875" x2="8.285721875" y2="44.978875" width="0.3048" layer="1"/>
 <wire x1="11.125" y1="42.342" x2="11.125" y2="41.275" width="0.508" layer="16"/>
 <wire x1="3.191284375" y1="38.11628125" x2="3.175003125" y2="38.1" width="0.254" layer="16"/>
 <wire x1="3.175003125" y1="38.1" x2="1.397" y2="38.1" width="0.254" layer="16"/>
 <via x="1.397" y="38.1" extent="1-16" drill="0.3048"/>
-<wire x1="2.646121875" y1="39.339275" x2="2.636275" y2="39.339275" width="0.254" layer="1"/>
-<wire x1="1.397" y1="38.1" x2="2.636275" y2="39.339275" width="0.254" layer="1"/>
-<wire x1="6.0227" y1="33.484146875" x2="4.826" y2="32.287446875" width="0.254" layer="1"/>
 <wire x1="4.826" y1="32.287446875" x2="4.826" y2="31.75" width="0.254" layer="1"/>
 <via x="4.826" y="31.75" extent="1-16" drill="0.3048"/>
 <wire x1="4.826" y1="31.75" x2="4.826" y2="32.1635625" width="0.254" layer="16"/>
@@ -1149,12 +1137,7 @@ design rules under a new name.</description>
 <wire x1="12.986565625" y1="31.242" x2="13.716" y2="31.242" width="0.254" layer="16"/>
 <via x="13.716" y="31.242" extent="1-16" drill="0.3048"/>
 <wire x1="13.716" y1="31.242" x2="12.98463125" y2="31.242" width="0.254" layer="1"/>
-<wire x1="11.8957875" y1="32.352634375" x2="11.8957875" y2="32.33084375" width="0.254" layer="1"/>
-<wire x1="12.98463125" y1="31.242" x2="11.8957875" y2="32.33084375" width="0.254" layer="1"/>
-<wire x1="2.674603125" y1="35.753865625" x2="1.808140625" y2="35.753865625" width="0.254" layer="1"/>
 <wire x1="1.808140625" y1="35.753865625" x2="1.412265625" y2="36.149740625" width="0.254" layer="1"/>
-<wire x1="3.202896875" y1="36.303946875" x2="3.202896875" y2="36.282159375" width="0.254" layer="1"/>
-<wire x1="3.202896875" y1="36.282159375" x2="2.674603125" y2="35.753865625" width="0.254" layer="1"/>
 <wire x1="1.412265625" y1="38.084734375" x2="1.397" y2="38.1" width="0.254" layer="1"/>
 <wire x1="1.412265625" y1="36.149740625" x2="1.412265625" y2="38.084734375" width="0.254" layer="1"/>
 <wire x1="8.55621875" y1="35.672346875" x2="8.55621875" y2="35.799346875" width="0.508" layer="16"/>
@@ -1163,18 +1146,31 @@ design rules under a new name.</description>
 <wire x1="10.112784375" y1="34.24278125" x2="10.938284375" y2="33.41728125" width="0.508" layer="16"/>
 <wire x1="7.92121875" y1="35.25878125" x2="8.6034375" y2="35.25878125" width="0.508" layer="16"/>
 <wire x1="8.6034375" y1="35.25878125" x2="9.57221875" y2="34.29" width="0.508" layer="16"/>
-<wire x1="9.57221875" y1="33.02" x2="9.57221875" y2="33.702215625" width="0.508" layer="16"/>
 <wire x1="9.57221875" y1="33.702215625" x2="10.112784375" y2="34.24278125" width="0.508" layer="16"/>
+<contactref element="U1" pad="34"/>
+<contactref element="U1" pad="14"/>
+<contactref element="U1" pad="2"/>
+<contactref element="U1" pad="24"/>
+<contactref element="U1" pad="44"/>
+<contactref element="U1" pad="7"/>
+<wire x1="6.0227" y1="33.484146875" x2="4.826" y2="32.287446875" width="0.254" layer="1"/>
+<wire x1="7.550175" y1="45.714421875" x2="8.285721875" y2="44.978875" width="0.3048" layer="1"/>
+<wire x1="15.8471" y1="39.89605" x2="15.89305" y2="39.89605" width="0.254" layer="1"/>
+<wire x1="15.89305" y1="39.89605" x2="17.145" y2="41.148" width="0.254" layer="1"/>
+<wire x1="12.98463125" y1="31.242" x2="11.8957875" y2="32.33084375" width="0.254" layer="1"/>
+<wire x1="11.8957875" y1="32.33084375" x2="11.8957875" y2="32.352634375" width="0.254" layer="1"/>
+<wire x1="1.397" y1="38.1" x2="2.636275" y2="39.339275" width="0.254" layer="1"/>
+<wire x1="2.636275" y1="39.339275" x2="2.646121875" y2="39.339275" width="0.254" layer="1"/>
+<wire x1="3.202896875" y1="36.303946875" x2="2.652815625" y2="35.753865625" width="0.254" layer="1"/>
+<wire x1="2.652815625" y1="35.753865625" x2="1.808140625" y2="35.753865625" width="0.254" layer="1"/>
 </signal>
 <signal name="N$3">
 <contactref element="RESET" pad="2A"/>
 <contactref element="RESET" pad="2B"/>
 <wire x1="12.095" y1="10.398" x2="6.955" y2="10.398" width="0.254" layer="1"/>
 <wire x1="6.955" y1="10.398" x2="6.955" y2="12.402" width="0.254" layer="1"/>
-<contactref element="U1" pad="13"/>
 <contactref element="R1" pad="2"/>
 <wire x1="6.955" y1="12.402" x2="8.523" y2="13.97" width="0.254" layer="1"/>
-<wire x1="11.32105" y1="31.777896875" x2="12.446" y2="30.652946875" width="0.254" layer="1"/>
 <wire x1="12.446" y1="30.652946875" x2="12.446" y2="30.226" width="0.254" layer="1"/>
 <via x="12.446" y="30.226" extent="1-16" drill="0.3048"/>
 <wire x1="12.446" y1="30.226" x2="12.446" y2="21.082" width="0.254" layer="16"/>
@@ -1182,12 +1178,14 @@ design rules under a new name.</description>
 <via x="8.509" y="17.145" extent="1-16" drill="0.35"/>
 <wire x1="8.523" y1="13.97" x2="8.509" y2="13.984" width="0.254" layer="1"/>
 <wire x1="8.509" y1="17.145" x2="8.509" y2="13.984" width="0.254" layer="1"/>
+<contactref element="U1" pad="13"/>
+<wire x1="11.32105" y1="31.777896875" x2="12.446" y2="30.652946875" width="0.254" layer="1"/>
 </signal>
 <signal name="UCAP">
 <contactref element="C3" pad="1"/>
-<wire x1="3.175" y1="31.75" x2="3.175" y2="31.355" width="0.254" layer="1"/>
 <contactref element="U1" pad="6"/>
 <wire x1="5.465921875" y1="34.040921875" x2="3.175" y2="31.75" width="0.254" layer="1"/>
+<wire x1="3.175" y1="31.75" x2="3.175" y2="31.355" width="0.254" layer="1"/>
 </signal>
 <signal name="N$5">
 <contactref element="USB1" pad="D+"/>
@@ -1203,13 +1201,13 @@ design rules under a new name.</description>
 <wire x1="7.874" y1="49.149" x2="7.874" y2="39.862196875" width="0.254" layer="16"/>
 <wire x1="4.833896875" y1="36.82209375" x2="7.874" y2="39.862196875" width="0.254" layer="16"/>
 <wire x1="4.833896875" y1="36.82209375" x2="2.68271875" y2="34.671" width="0.254" layer="16"/>
-<contactref element="U1" pad="3"/>
 <via x="1.778" y="34.671" extent="1-16" drill="0.3048"/>
-<wire x1="2.723378125" y1="34.689090625" x2="3.763496875" y2="35.729209375" width="0.254" layer="1"/>
-<wire x1="3.763496875" y1="35.729209375" x2="3.777634375" y2="35.729209375" width="0.254" layer="1"/>
 <wire x1="1.778" y1="34.671" x2="1.796090625" y2="34.689090625" width="0.254" layer="1"/>
-<wire x1="1.796090625" y1="34.689090625" x2="2.723378125" y2="34.689090625" width="0.254" layer="1"/>
+<wire x1="1.796090625" y1="34.689090625" x2="2.794" y2="34.689090625" width="0.254" layer="1"/>
 <wire x1="2.68271875" y1="34.671" x2="1.778" y2="34.671" width="0.254" layer="16"/>
+<contactref element="U1" pad="3"/>
+<wire x1="3.777634375" y1="35.729209375" x2="3.777634375" y2="35.672725" width="0.254" layer="1"/>
+<wire x1="3.777634375" y1="35.672725" x2="2.794" y2="34.689090625" width="0.254" layer="1"/>
 </signal>
 <signal name="N$7">
 <contactref element="USB1" pad="D-"/>
@@ -1224,12 +1222,12 @@ design rules under a new name.</description>
 <via x="9.525" y="49.149" extent="1-16" drill="0.3048"/>
 <wire x1="9.525" y1="49.149" x2="9.525" y2="40.729021875" width="0.254" layer="16"/>
 <wire x1="9.525" y1="40.729021875" x2="2.92094375" y2="34.124965625" width="0.254" layer="16"/>
-<contactref element="U1" pad="4"/>
 <wire x1="2.92094375" y1="34.124965625" x2="2.921" y2="33.401" width="0.254" layer="16"/>
 <via x="2.921" y="33.401" extent="1-16" drill="0.3048"/>
 <wire x1="2.921" y1="33.401" x2="2.921" y2="33.782" width="0.254" layer="1"/>
-<wire x1="4.311434375" y1="35.172434375" x2="2.921" y2="33.782" width="0.254" layer="1"/>
-<wire x1="4.311434375" y1="35.172434375" x2="4.334409375" y2="35.172434375" width="0.254" layer="1"/>
+<contactref element="U1" pad="4"/>
+<wire x1="2.921" y1="33.401" x2="2.921" y2="33.759025" width="0.254" layer="1"/>
+<wire x1="2.921" y1="33.759025" x2="4.334409375" y2="35.172434375" width="0.254" layer="1"/>
 </signal>
 <signal name="N$9">
 <contactref element="SW01" pad="MX2"/>
@@ -1257,14 +1255,14 @@ design rules under a new name.</description>
 <wire x1="63.461" y1="29.347925" x2="63.461" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="63.461" y1="27.802075" x2="62.865" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="62.865" y1="27.206075" x2="62.865" y2="12.065" width="0.254" layer="16"/>
-<contactref element="U1" pad="31"/>
-<wire x1="16.891" y1="48.842575" x2="11.8957875" y2="43.8473625" width="0.254" layer="1"/>
 <wire x1="16.891" y1="68.58" x2="21.971" y2="73.66" width="0.254" layer="1"/>
 <wire x1="21.971" y1="73.66" x2="51.562" y2="73.66" width="0.254" layer="1"/>
 <wire x1="62.191" y1="68.541" x2="62.865" y2="69.215" width="0.254" layer="1"/>
 <wire x1="56.681" y1="68.541" x2="62.191" y2="68.541" width="0.254" layer="1"/>
-<wire x1="16.891" y1="48.842575" x2="16.891" y2="68.58" width="0.254" layer="1"/>
+<wire x1="16.891" y1="68.58" x2="16.891" y2="48.842575" width="0.254" layer="1"/>
 <wire x1="51.562" y1="73.66" x2="56.681" y2="68.541" width="0.254" layer="1"/>
+<contactref element="U1" pad="31"/>
+<wire x1="16.891" y1="48.842575" x2="11.8957875" y2="43.8473625" width="0.254" layer="1"/>
 </signal>
 <signal name="N$12">
 <contactref element="SW02" pad="MX2"/>
@@ -1288,9 +1286,9 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="2.54" x2="39.37" y2="3.81" width="0.254" layer="1"/>
 <wire x1="39.37" y1="3.81" x2="39.37" y2="5.715" width="0.254" layer="1"/>
 <wire x1="38.1" y1="2.54" x2="38.1" y2="1.27" width="0.254" layer="1"/>
+<wire x1="17.219575" y1="42.418" x2="18.161" y2="42.418" width="0.254" layer="1"/>
 <contactref element="U1" pad="25"/>
 <wire x1="15.2723625" y1="40.4707875" x2="17.219575" y2="42.418" width="0.254" layer="1"/>
-<wire x1="17.219575" y1="42.418" x2="18.161" y2="42.418" width="0.254" layer="1"/>
 </signal>
 <signal name="N$15">
 <contactref element="SW03" pad="MX2"/>
@@ -1318,11 +1316,11 @@ design rules under a new name.</description>
 <wire x1="25.361" y1="29.347925" x2="25.361" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="25.361" y1="27.802075" x2="24.765" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="24.765" y1="27.206075" x2="24.765" y2="12.065" width="0.254" layer="16"/>
-<contactref element="U1" pad="29"/>
-<wire x1="13.027296875" y1="42.71585" x2="18.3896" y2="48.078153125" width="0.254" layer="1"/>
 <wire x1="18.3896" y1="67.9196" x2="19.685" y2="69.215" width="0.254" layer="1"/>
 <wire x1="19.685" y1="69.215" x2="24.765" y2="69.215" width="0.254" layer="1"/>
 <wire x1="18.3896" y1="48.078153125" x2="18.3896" y2="67.9196" width="0.254" layer="1"/>
+<contactref element="U1" pad="29"/>
+<wire x1="13.027296875" y1="42.71585" x2="18.3896" y2="48.078153125" width="0.254" layer="1"/>
 </signal>
 <signal name="N$18">
 <contactref element="SW04" pad="MX2"/>
@@ -1355,12 +1353,12 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="21.59" x2="38.1" y2="20.32" width="0.254" layer="1"/>
 <wire x1="39.37" y1="24.765" x2="39.37" y2="22.86" width="0.254" layer="1"/>
 <wire x1="39.37" y1="22.86" x2="38.1" y2="21.59" width="0.254" layer="1"/>
-<contactref element="U1" pad="26"/>
-<wire x1="18.5166" y1="43.2054" x2="16.893425" y2="43.2054" width="0.254" layer="1"/>
-<wire x1="16.893425" y1="43.2054" x2="14.7155875" y2="41.0275625" width="0.254" layer="1"/>
+<wire x1="16.893425" y1="43.2054" x2="18.5166" y2="43.2054" width="0.254" layer="1"/>
 <wire x1="19.558" y1="42.164" x2="18.5166" y2="43.2054" width="0.254" layer="1"/>
 <wire x1="19.558" y1="21.59" x2="20.828" y2="20.32" width="0.254" layer="1"/>
 <wire x1="20.828" y1="20.32" x2="38.1" y2="20.32" width="0.254" layer="1"/>
+<contactref element="U1" pad="26"/>
+<wire x1="14.7155875" y1="41.0275625" x2="16.893425" y2="43.2054" width="0.254" layer="1"/>
 </signal>
 <signal name="N$27">
 <contactref element="SW07" pad="MX2"/>
@@ -1386,13 +1384,13 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="40.64" x2="39.37" y2="41.91" width="0.254" layer="1"/>
 <wire x1="39.37" y1="41.91" x2="39.37" y2="43.815" width="0.254" layer="1"/>
 <wire x1="38.1" y1="40.64" x2="38.1" y2="39.37" width="0.254" layer="1"/>
-<contactref element="U1" pad="27"/>
-<wire x1="14.14085" y1="41.602296875" x2="16.480553125" y2="43.942" width="0.254" layer="1"/>
-<wire x1="18.796" y1="43.942" x2="16.480553125" y2="43.942" width="0.254" layer="1"/>
+<wire x1="16.480553125" y1="43.942" x2="18.796" y2="43.942" width="0.254" layer="1"/>
 <wire x1="18.796" y1="43.942" x2="20.193" y2="42.545" width="0.254" layer="1"/>
 <wire x1="21.59" y1="39.37" x2="20.193" y2="40.767" width="0.254" layer="1"/>
 <wire x1="20.193" y1="40.767" x2="20.193" y2="42.545" width="0.254" layer="1"/>
 <wire x1="38.1" y1="39.37" x2="21.59" y2="39.37" width="0.254" layer="1"/>
+<contactref element="U1" pad="27"/>
+<wire x1="14.14085" y1="41.602296875" x2="16.480553125" y2="43.942" width="0.254" layer="1"/>
 </signal>
 <signal name="N$33">
 <contactref element="SW09" pad="MX2"/>
@@ -1450,14 +1448,13 @@ design rules under a new name.</description>
 <wire x1="44.411" y1="29.347925" x2="44.411" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="44.411" y1="27.802075" x2="43.815" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="43.815" y1="27.206075" x2="43.815" y2="12.065" width="0.254" layer="16"/>
-<contactref element="U1" pad="30"/>
-<wire x1="12.4525625" y1="43.2905875" x2="12.4525625" y2="43.3135625" width="0.254" layer="1"/>
-<wire x1="17.653" y1="48.491025" x2="12.4525625" y2="43.2905875" width="0.254" layer="1"/>
-<wire x1="17.653" y1="48.491025" x2="17.653" y2="68.2657375" width="0.254" layer="1"/>
+<wire x1="17.653" y1="68.2657375" x2="17.653" y2="48.491025" width="0.254" layer="1"/>
 <wire x1="17.653" y1="68.2657375" x2="20.4056625" y2="71.0184" width="0.254" layer="1"/>
 <wire x1="20.4056625" y1="71.0184" x2="28.87786875" y2="71.0184" width="0.254" layer="1"/>
 <wire x1="28.87786875" y1="71.0184" x2="30.68126875" y2="69.215" width="0.254" layer="1"/>
 <wire x1="30.68126875" y1="69.215" x2="43.815" y2="69.215" width="0.254" layer="1"/>
+<contactref element="U1" pad="30"/>
+<wire x1="17.653" y1="48.491025" x2="12.4525625" y2="43.2905875" width="0.254" layer="1"/>
 </signal>
 <signal name="N$42">
 <contactref element="SW12" pad="MX2"/>
@@ -1466,10 +1463,10 @@ design rules under a new name.</description>
 <wire x1="35.56" y1="71.755" x2="36.83" y2="70.485" width="0.254" layer="1"/>
 </signal>
 <signal name="N$4">
-<contactref element="U1" pad="33"/>
 <contactref element="R2" pad="2"/>
-<wire x1="10.764275" y1="44.978875" x2="12.446" y2="46.6606" width="0.254" layer="1"/>
 <wire x1="12.446" y1="46.6606" x2="12.446" y2="51.195" width="0.254" layer="1"/>
+<contactref element="U1" pad="33"/>
+<wire x1="10.764275" y1="44.978875" x2="12.446" y2="46.6606" width="0.254" layer="1"/>
 </signal>
 <signal name="N$11">
 <contactref element="USB1" pad="SHIELD@1"/>
@@ -1525,13 +1522,13 @@ design rules under a new name.</description>
 <vertex x="77.47" y="-1.27"/>
 <vertex x="-1.27" y="-1.27"/>
 </polygon>
+<contactref element="Y1" pad="4"/>
+<contactref element="Y1" pad="2"/>
 <contactref element="U1" pad="15"/>
 <contactref element="U1" pad="23"/>
 <contactref element="U1" pad="35"/>
 <contactref element="U1" pad="43"/>
 <contactref element="U1" pad="5"/>
-<contactref element="Y1" pad="4"/>
-<contactref element="Y1" pad="2"/>
 </signal>
 </signals>
 <mfgpreviewcolors>

--- a/PCB/MacroPad.brd
+++ b/PCB/MacroPad.brd
@@ -821,53 +821,53 @@ design rules under a new name.</description>
 </pass>
 </autorouter>
 <elements>
-<element name="C1" library="Components" package="C0603" value="22p" x="14.986" y="28.575" smashed="yes" rot="R90">
-<attribute name="MF" value="" x="14.986" y="28.575" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="MPN" value="04025A220JAT2A" x="14.986" y="28.575" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="NAME" x="15.606" y="28.537" size="1" layer="25" ratio="13" rot="R90" align="top-center"/>
-<attribute name="OC_NEWARK" value="96M1143" x="14.986" y="28.575" size="1.778" layer="27" rot="R90" display="off"/>
+<element name="C1" library="Components" package="C0603" value="22p" x="17.018" y="27.559" smashed="yes" rot="R90">
+<attribute name="MF" value="" x="17.018" y="27.559" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MPN" value="04025A220JAT2A" x="17.018" y="27.559" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="NAME" x="17.638" y="27.521" size="1" layer="25" ratio="13" rot="R90" align="top-center"/>
+<attribute name="OC_NEWARK" value="96M1143" x="17.018" y="27.559" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="C2" library="Components" package="C0603" value="22p" x="8.636" y="28.575" smashed="yes" rot="R270">
-<attribute name="MF" value="" x="8.636" y="28.575" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="MPN" value="04025A220JAT2A" x="8.636" y="28.575" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="NAME" x="7.889" y="28.613" size="1" layer="25" ratio="13" rot="R270" align="top-center"/>
-<attribute name="OC_NEWARK" value="96M1143" x="8.636" y="28.575" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="C2" library="Components" package="C0603" value="22p" x="10.668" y="27.559" smashed="yes" rot="R270">
+<attribute name="MF" value="" x="10.668" y="27.559" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MPN" value="04025A220JAT2A" x="10.668" y="27.559" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="9.921" y="27.597" size="1" layer="25" ratio="13" rot="R270" align="top-center"/>
+<attribute name="OC_NEWARK" value="96M1143" x="10.668" y="27.559" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="C3" library="Components" package="C0603" value="4.7u" x="6.477" y="44.45" smashed="yes" rot="R225">
-<attribute name="MF" value="" x="6.477" y="44.45" size="1.778" layer="27" rot="R225" display="off"/>
-<attribute name="MPN" value="" x="6.477" y="44.45" size="1.778" layer="27" rot="R225" display="off"/>
-<attribute name="NAME" x="5.960253125" y="44.955115625" size="1" layer="25" ratio="13" rot="R225" align="top-center"/>
-<attribute name="OC_NEWARK" value="unknown" x="6.477" y="44.45" size="1.778" layer="27" rot="R225" display="off"/>
+<element name="C3" library="Components" package="C0603" value="4.7u" x="4.953" y="46.101" smashed="yes" rot="R225">
+<attribute name="MF" value="" x="4.953" y="46.101" size="1.778" layer="27" rot="R225" display="off"/>
+<attribute name="MPN" value="" x="4.953" y="46.101" size="1.778" layer="27" rot="R225" display="off"/>
+<attribute name="NAME" x="4.436253125" y="46.606115625" size="1" layer="25" ratio="13" rot="R225" align="top-center"/>
+<attribute name="OC_NEWARK" value="unknown" x="4.953" y="46.101" size="1.778" layer="27" rot="R225" display="off"/>
 </element>
-<element name="C4" library="Components" package="C0603" value="0.1u" x="6.985" y="35.56" smashed="yes" rot="MR45">
-<attribute name="MF" value="" x="6.985" y="35.56" size="1.778" layer="28" rot="MR45" display="off"/>
-<attribute name="MPN" value="" x="6.985" y="35.56" size="1.778" layer="28" rot="MR45" display="off"/>
-<attribute name="NAME" x="7.502303125" y="36.08893125" size="1" layer="26" ratio="13" rot="MR45" align="bottom-center"/>
-<attribute name="OC_NEWARK" value="unknown" x="6.985" y="35.56" size="1.778" layer="28" rot="MR45" display="off"/>
+<element name="C4" library="Components" package="C0603" value="0.1u" x="6.35" y="34.925" smashed="yes" rot="MR45">
+<attribute name="MF" value="" x="6.35" y="34.925" size="1.778" layer="28" rot="MR45" display="off"/>
+<attribute name="MPN" value="" x="6.35" y="34.925" size="1.778" layer="28" rot="MR45" display="off"/>
+<attribute name="NAME" x="6.867303125" y="35.45393125" size="1" layer="26" ratio="13" rot="MR45" align="bottom-center"/>
+<attribute name="OC_NEWARK" value="unknown" x="6.35" y="34.925" size="1.778" layer="28" rot="MR45" display="off"/>
 </element>
-<element name="C5" library="Components" package="C0603" value="0.1u" x="5.588" y="38.862" smashed="yes" rot="MR135">
-<attribute name="MF" value="" x="5.588" y="38.862" size="1.778" layer="28" rot="MR135" display="off"/>
-<attribute name="MPN" value="" x="5.588" y="38.862" size="1.778" layer="28" rot="MR135" display="off"/>
-<attribute name="NAME" x="6.11693125" y="38.344690625" size="1" layer="26" ratio="13" rot="MR135" align="bottom-center"/>
-<attribute name="OC_NEWARK" value="unknown" x="5.588" y="38.862" size="1.778" layer="28" rot="MR135" display="off"/>
+<element name="C5" library="Components" package="C0603" value="0.1u" x="3.81" y="38.735" smashed="yes" rot="MR135">
+<attribute name="MF" value="" x="3.81" y="38.735" size="1.778" layer="28" rot="MR135" display="off"/>
+<attribute name="MPN" value="" x="3.81" y="38.735" size="1.778" layer="28" rot="MR135" display="off"/>
+<attribute name="NAME" x="4.33893125" y="38.217690625" size="1" layer="26" ratio="13" rot="MR135" align="bottom-center"/>
+<attribute name="OC_NEWARK" value="unknown" x="3.81" y="38.735" size="1.778" layer="28" rot="MR135" display="off"/>
 </element>
-<element name="C6" library="Components" package="C0603" value="0.1u" x="10.922" y="34.671" smashed="yes" rot="MR135">
-<attribute name="MF" value="" x="10.922" y="34.671" size="1.778" layer="28" rot="MR135" display="off"/>
-<attribute name="MPN" value="" x="10.922" y="34.671" size="1.778" layer="28" rot="MR135" display="off"/>
-<attribute name="NAME" x="10.43493125" y="35.04269375" size="1" layer="26" ratio="13" rot="MR135" align="top-center"/>
-<attribute name="OC_NEWARK" value="unknown" x="10.922" y="34.671" size="1.778" layer="28" rot="MR135" display="off"/>
+<element name="C6" library="Components" package="C0603" value="0.1u" x="11.557" y="33.909" smashed="yes" rot="MR135">
+<attribute name="MF" value="" x="11.557" y="33.909" size="1.778" layer="28" rot="MR135" display="off"/>
+<attribute name="MPN" value="" x="11.557" y="33.909" size="1.778" layer="28" rot="MR135" display="off"/>
+<attribute name="NAME" x="11.06993125" y="34.28069375" size="1" layer="26" ratio="13" rot="MR135" align="top-center"/>
+<attribute name="OC_NEWARK" value="unknown" x="11.557" y="33.909" size="1.778" layer="28" rot="MR135" display="off"/>
 </element>
-<element name="C7" library="Components" package="C0603" value="0.1u" x="13.716" y="38.481" smashed="yes" rot="MR225">
-<attribute name="MF" value="" x="13.716" y="38.481" size="1.778" layer="28" rot="MR225" display="off"/>
-<attribute name="MPN" value="" x="13.716" y="38.481" size="1.778" layer="28" rot="MR225" display="off"/>
-<attribute name="NAME" x="13.19869375" y="37.952065625" size="1" layer="26" ratio="13" rot="MR225" align="bottom-center"/>
-<attribute name="OC_NEWARK" value="unknown" x="13.716" y="38.481" size="1.778" layer="28" rot="MR225" display="off"/>
+<element name="C7" library="Components" package="C0603" value="0.1u" x="14.986" y="38.481" smashed="yes" rot="MR225">
+<attribute name="MF" value="" x="14.986" y="38.481" size="1.778" layer="28" rot="MR225" display="off"/>
+<attribute name="MPN" value="" x="14.986" y="38.481" size="1.778" layer="28" rot="MR225" display="off"/>
+<attribute name="NAME" x="14.46869375" y="37.952065625" size="1" layer="26" ratio="13" rot="MR225" align="bottom-center"/>
+<attribute name="OC_NEWARK" value="unknown" x="14.986" y="38.481" size="1.778" layer="28" rot="MR225" display="off"/>
 </element>
-<element name="C8" library="Components" package="C0603" value="1u" x="4.826" y="31.75" smashed="yes" rot="R270">
-<attribute name="MF" value="" x="4.826" y="31.75" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="MPN" value="" x="4.826" y="31.75" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="NAME" x="5.476" y="31.661" size="1" layer="25" ratio="13" rot="R270" align="bottom-center"/>
-<attribute name="OC_NEWARK" value="unknown" x="4.826" y="31.75" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="C8" library="Components" package="C0603" value="1u" x="3.556" y="30.48" smashed="yes" rot="R270">
+<attribute name="MF" value="" x="3.556" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MPN" value="" x="3.556" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="4.206" y="30.391" size="1" layer="25" ratio="13" rot="R270" align="bottom-center"/>
+<attribute name="OC_NEWARK" value="unknown" x="3.556" y="30.48" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
 <element name="F1" library="USB" package="F0805" value="" x="13.335" y="64.008" smashed="yes" rot="R90">
 <attribute name="MF" value="" x="13.335" y="64.008" size="1.778" layer="27" rot="R90" display="off"/>
@@ -984,18 +984,18 @@ design rules under a new name.</description>
 <attribute name="OC_NEWARK" value="unknown" x="9.525" y="76.2" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="VALUE" x="3.81" y="74.93" size="1.27" layer="27" rot="R270"/>
 </element>
-<element name="Y1" library="Components" package="CRYSTAL-3.2X2.5" value="" x="11.811" y="28.575" smashed="yes" rot="R180">
-<attribute name="MF" value="" x="11.811" y="28.575" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="MPN" value="" x="11.811" y="28.575" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="NAME" x="11.811" y="26.925" size="1.27" layer="21" font="vector" rot="R180" align="bottom-center"/>
-<attribute name="OC_NEWARK" value="unknown" x="11.811" y="28.575" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="VALUE" x="11.811" y="30.225" size="1.27" layer="21" font="vector" rot="R180" align="top-center"/>
+<element name="Y1" library="Components" package="CRYSTAL-3.2X2.5" value="" x="13.843" y="27.559" smashed="yes" rot="R180">
+<attribute name="MF" value="" x="13.843" y="27.559" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="MPN" value="" x="13.843" y="27.559" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="13.843" y="25.909" size="1.27" layer="21" font="vector" rot="R180" align="bottom-center"/>
+<attribute name="OC_NEWARK" value="unknown" x="13.843" y="27.559" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="VALUE" x="13.843" y="29.209" size="1.27" layer="21" font="vector" rot="R180" align="top-center"/>
 </element>
-<element name="C9" library="Components" package="C0603" value="0.1u" x="7.493" y="43.434" smashed="yes" rot="R226">
-<attribute name="MF" value="" x="7.493" y="43.434" size="1.778" layer="27" rot="R226" display="off"/>
-<attribute name="MPN" value="" x="7.493" y="43.434" size="1.778" layer="27" rot="R226" display="off"/>
-<attribute name="NAME" x="6.35729375" y="42.160940625" size="1" layer="25" ratio="13" rot="R226" align="center-left"/>
-<attribute name="OC_NEWARK" value="unknown" x="7.493" y="43.434" size="1.778" layer="27" rot="R226" display="off"/>
+<element name="C9" library="Components" package="C0603" value="0.1u" x="5.969" y="45.085" smashed="yes" rot="R226">
+<attribute name="MF" value="" x="5.969" y="45.085" size="1.778" layer="27" rot="R226" display="off"/>
+<attribute name="MPN" value="" x="5.969" y="45.085" size="1.778" layer="27" rot="R226" display="off"/>
+<attribute name="NAME" x="4.83329375" y="43.811940625" size="1" layer="25" ratio="13" rot="R226" align="center-left"/>
+<attribute name="OC_NEWARK" value="unknown" x="5.969" y="45.085" size="1.778" layer="27" rot="R226" display="off"/>
 </element>
 <element name="D12" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1" value="" x="36.83" y="66.675" smashed="yes" rot="R270">
 <attribute name="NAME" x="38.1" y="69.215" size="0.4064" layer="25" rot="R270"/>
@@ -1045,48 +1045,41 @@ design rules under a new name.</description>
 <attribute name="NAME" x="40.64" y="69.215" size="0.4064" layer="25" rot="R270"/>
 <attribute name="VALUE" x="39.116" y="68.707" size="0.6096" layer="21" rot="R270"/>
 </element>
-<element name="U1" library="ATMEGA32U4-AUR" package="QFP80P1200X1200X120-44N" value="ATMEGA32U4-AUR" x="-10.16" y="10.16" smashed="yes">
-<attribute name="AVAILABILITY" value="Unavailable" x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
-<attribute name="DESCRIPTION" value=" ATmega Series 16 MHz 32 KB Flash 2.5 KB SRAM 8-Bit Microcontroller - TQFP-44 " x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
-<attribute name="MF" value="Microchip" x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
-<attribute name="MP" value="ATMEGA32U4-AUR" x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
-<attribute name="NAME" x="-14.33045" y="0.0645" size="2.08521875" layer="25" ratio="10" rot="SR0"/>
-<attribute name="PACKAGE" value="TQFP-44 Microchip" x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
-<attribute name="PRICE" value="None" x="-10.16" y="10.16" size="1.778" layer="27" display="off"/>
-<attribute name="VALUE" x="-13.62611875" y="20.278" size="2.089859375" layer="27" ratio="10" rot="SR0"/>
+<element name="U1" library="ATMEGA32U4-AUR" package="QFP80P1200X1200X120-44N" value="ATMEGA32U4-AUR" x="9.525" y="38.1" smashed="yes" rot="R45">
+<attribute name="AVAILABILITY" value="Unavailable" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
+<attribute name="DESCRIPTION" value=" ATmega Series 16 MHz 32 KB Flash 2.5 KB SRAM 8-Bit Microcontroller - TQFP-44 " x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
+<attribute name="MF" value="Microchip" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
+<attribute name="MP" value="ATMEGA32U4-AUR" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
+<attribute name="PACKAGE" value="TQFP-44 Microchip" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
+<attribute name="PRICE" value="None" x="9.525" y="38.1" size="1.778" layer="27" rot="R45" display="off"/>
 </element>
 </elements>
 <signals>
 <signal name="N$1">
 <contactref element="Y1" pad="3"/>
 <contactref element="C2" pad="2"/>
-<wire x1="12.31823125" y1="34.5666" x2="12.8453875" y2="34.5666" width="0.254" layer="1"/>
-<wire x1="12.8453875" y1="34.5666" x2="13.716" y2="33.6959875" width="0.254" layer="1"/>
-<wire x1="13.716" y1="33.6959875" x2="13.716" y2="33.02" width="0.254" layer="1"/>
-<wire x1="13.716" y1="33.02" x2="11.938" y2="31.242" width="0.254" layer="1"/>
-<wire x1="11.938" y1="31.242" x2="10.541" y2="31.242" width="0.254" layer="1"/>
-<via x="10.541" y="31.242" extent="1-16" drill="0.3048"/>
-<wire x1="10.541" y1="31.242" x2="10.541" y2="25.4" width="0.254" layer="16"/>
-<via x="10.541" y="25.4" extent="1-16" drill="0.3048"/>
-<wire x1="10.661" y1="27.65" x2="10.541" y2="27.53" width="0.254" layer="1"/>
-<wire x1="10.541" y1="27.53" x2="10.541" y2="25.4" width="0.254" layer="1"/>
-<wire x1="8.636" y1="27.7" x2="10.611" y2="27.7" width="0.254" layer="1"/>
-<wire x1="10.611" y1="27.7" x2="10.661" y2="27.65" width="0.254" layer="1"/>
+<via x="12.7" y="25.273" extent="1-16" drill="0.3048"/>
+<wire x1="12.693" y1="26.634" x2="12.7" y2="26.627" width="0.254" layer="1"/>
+<wire x1="12.7" y1="26.627" x2="12.7" y2="25.273" width="0.254" layer="1"/>
+<wire x1="10.668" y1="26.684" x2="12.643" y2="26.684" width="0.254" layer="1"/>
+<wire x1="12.643" y1="26.684" x2="12.693" y2="26.634" width="0.254" layer="1"/>
 <contactref element="U1" pad="16"/>
-<wire x1="-10.9474" y1="4.4196" x2="10.541" y2="25.4" width="0" layer="19" extent="1-16"/>
+<wire x1="13.027296875" y1="33.484146875" x2="14.478" y2="32.03344375" width="0.254" layer="1"/>
+<wire x1="14.478" y1="32.03344375" x2="14.478" y2="29.972" width="0.254" layer="1"/>
+<via x="14.478" y="29.972" extent="1-16" drill="0.35"/>
+<wire x1="14.478" y1="29.972" x2="14.478" y2="25.781" width="0.254" layer="16"/>
+<wire x1="14.478" y1="25.781" x2="13.97" y2="25.273" width="0.254" layer="16"/>
+<wire x1="13.97" y1="25.273" x2="12.7" y2="25.273" width="0.254" layer="16"/>
 </signal>
 <signal name="N$2">
 <contactref element="Y1" pad="1"/>
 <contactref element="C1" pad="2"/>
-<wire x1="12.961" y1="29.5" x2="14.936" y2="29.5" width="0.254" layer="1"/>
-<wire x1="14.936" y1="29.5" x2="14.986" y2="29.45" width="0.254" layer="1"/>
-<wire x1="12.618925" y1="34.973" x2="13.013725" y2="34.973" width="0.254" layer="1"/>
-<wire x1="12.961" y1="31.6902625" x2="12.961" y2="29.5" width="0.254" layer="1"/>
-<wire x1="13.013725" y1="34.973" x2="14.1224" y2="33.864325" width="0.254" layer="1"/>
-<wire x1="14.1224" y1="33.864325" x2="14.1224" y2="32.8516625" width="0.254" layer="1"/>
-<wire x1="14.1224" y1="32.8516625" x2="12.961" y2="31.6902625" width="0.254" layer="1"/>
+<wire x1="14.993" y1="28.484" x2="15.24" y2="28.484" width="0.254" layer="1"/>
+<wire x1="15.24" y1="28.484" x2="16.968" y2="28.484" width="0.254" layer="1"/>
+<wire x1="16.968" y1="28.484" x2="17.018" y2="28.434" width="0.254" layer="1"/>
 <contactref element="U1" pad="17"/>
-<wire x1="-10.16" y1="4.4196" x2="12.961" y2="29.5" width="0" layer="19" extent="1-1"/>
+<wire x1="13.584075" y1="34.040921875" x2="15.24" y2="32.384996875" width="0.254" layer="1"/>
+<wire x1="15.24" y1="32.384996875" x2="15.24" y2="28.484" width="0.254" layer="1"/>
 </signal>
 <signal name="VCC">
 <contactref element="C3" pad="1"/>
@@ -1096,83 +1089,92 @@ design rules under a new name.</description>
 <contactref element="C7" pad="1"/>
 <contactref element="R1" pad="1"/>
 <contactref element="USB1" pad="VCC"/>
-<wire x1="15.253734375" y1="39.855403125" x2="15.761734375" y2="39.347403125" width="0.254" layer="1"/>
-<wire x1="15.253734375" y1="39.855403125" x2="14.141834375" y2="39.855403125" width="0.254" layer="1"/>
-<via x="15.761734375" y="39.347403125" extent="1-16" drill="0.3048"/>
-<wire x1="15.761734375" y1="39.347403125" x2="15.253734375" y2="39.855403125" width="0.254" layer="16"/>
-<wire x1="15.253734375" y1="39.855403125" x2="13.852971875" y2="39.855403125" width="0.254" layer="16"/>
-<wire x1="13.852971875" y1="39.855403125" x2="13.097284375" y2="39.099715625" width="0.254" layer="16"/>
-<wire x1="12.323653125" y1="33.147" x2="12.446" y2="33.147" width="0.254" layer="1"/>
-<via x="12.446" y="33.147" extent="1-16" drill="0.3048"/>
-<wire x1="6.096" y1="33.996984375" x2="6.096" y2="33.782" width="0.254" layer="1"/>
-<via x="6.096" y="33.782" extent="1-16" drill="0.3048"/>
-<wire x1="7.60371875" y1="34.94128125" x2="6.27021875" y2="33.60778125" width="0.254" layer="16"/>
-<wire x1="6.096" y1="33.782" x2="6.27021875" y2="33.60778125" width="0.254" layer="16"/>
-<wire x1="3.990625" y1="40.132" x2="3.937" y2="40.132" width="0.254" layer="1"/>
-<via x="3.937" y="40.132" extent="1-16" drill="0.3048"/>
-<wire x1="3.937" y1="40.132" x2="3.937" y2="39.751" width="0.254" layer="16"/>
-<wire x1="4.969284375" y1="38.718715625" x2="3.937" y2="39.751" width="0.254" layer="16"/>
-<wire x1="4.969284375" y1="38.718715625" x2="4.969284375" y2="38.24328125" width="0.254" layer="16"/>
-<wire x1="11.125" y1="67.55" x2="11.125" y2="46.101" width="0.508" layer="1"/>
+<wire x1="15.192784375" y1="39.925215625" x2="14.367284375" y2="39.099715625" width="0.254" layer="16"/>
+<via x="2.159" y="43.942" extent="1-16" drill="0.3048"/>
+<wire x1="2.159" y1="43.942" x2="2.175284375" y2="43.925715625" width="0.254" layer="16"/>
+<wire x1="2.175284375" y1="43.925715625" x2="2.175284375" y2="39.13228125" width="0.254" layer="16"/>
+<wire x1="2.175284375" y1="39.13228125" x2="3.191284375" y2="38.11628125" width="0.254" layer="16"/>
+<wire x1="11.125" y1="48.26" x2="11.125" y2="67.55" width="0.508" layer="1"/>
 <contactref element="C9" pad="1"/>
-<wire x1="8.481825" y1="43.682421875" x2="8.100825" y2="44.063421875" width="0.254" layer="1"/>
-<wire x1="8.481825" y1="43.682421875" x2="8.481825" y2="42.71169375" width="0.254" layer="1"/>
-<wire x1="11.125" y1="47.117" x2="10.579" y2="46.571" width="0.508" layer="1"/>
-<wire x1="10.579" y1="46.571" x2="10.109" y2="46.101" width="0.508" layer="1"/>
-<wire x1="9.838715625" y1="45.830715625" x2="7.857715625" y2="45.830715625" width="0.508" layer="1"/>
-<wire x1="7.857715625" y1="45.830715625" x2="7.095715625" y2="45.068715625" width="0.508" layer="1"/>
-<wire x1="11.125" y1="47.117" x2="11.125" y2="46.101" width="0.508" layer="1"/>
-<via x="11.125" y="46.101" extent="1-16" drill="0.3048"/>
-<wire x1="11.125" y1="46.101" x2="11.125" y2="41.275" width="0.508" layer="16"/>
+<wire x1="7.5940625" y1="47.608715625" x2="7.577778125" y2="47.625" width="0.508" layer="1"/>
+<wire x1="6.460715625" y1="47.608715625" x2="5.571715625" y2="46.719715625" width="0.508" layer="1"/>
+<via x="11.125" y="47.625" extent="1-16" drill="0.3048"/>
+<wire x1="11.125" y1="47.625" x2="11.125" y2="42.342" width="0.508" layer="16"/>
+<wire x1="11.633" y1="41.783" x2="11.125" y2="41.275" width="0.508" layer="16"/>
 <wire x1="11.125" y1="41.275" x2="8.55621875" y2="38.70621875" width="0.508" layer="16"/>
-<wire x1="8.55621875" y1="35.89378125" x2="7.60371875" y2="34.94128125" width="0.508" layer="16"/>
-<wire x1="10.303284375" y1="34.05228125" x2="9.350784375" y2="35.00478125" width="0.508" layer="16"/>
+<wire x1="8.55621875" y1="35.89378125" x2="6.96871875" y2="34.30628125" width="0.508" layer="16"/>
+<wire x1="10.938284375" y1="33.29028125" x2="10.938284375" y2="33.41728125" width="0.508" layer="16"/>
+<wire x1="10.938284375" y1="33.41728125" x2="8.86639375" y2="35.489175" width="0.508" layer="16"/>
 <wire x1="9.350784375" y1="35.00478125" x2="8.96978125" y2="35.385784375" width="0.508" layer="16"/>
 <wire x1="8.96978125" y1="35.385784375" x2="8.55621875" y2="35.799346875" width="0.508" layer="16"/>
 <wire x1="8.55621875" y1="38.70621875" x2="8.55621875" y2="35.89378125" width="0.508" layer="16"/>
 <wire x1="8.55621875" y1="35.89378125" x2="8.55621875" y2="35.799346875" width="0.508" layer="16"/>
-<wire x1="3.937" y1="40.132" x2="3.937" y2="44.323" width="0.508" layer="1"/>
-<wire x1="3.937" y1="44.323" x2="5.444715625" y2="45.830715625" width="0.508" layer="1"/>
-<wire x1="5.444715625" y1="45.830715625" x2="6.35" y2="45.830715625" width="0.508" layer="1"/>
-<wire x1="6.35" y1="45.830715625" x2="7.857715625" y2="45.830715625" width="0.508" layer="1"/>
-<wire x1="7.095715625" y1="45.068715625" x2="8.100825" y2="44.06360625" width="0.508" layer="1"/>
-<wire x1="8.100825" y1="44.06360625" x2="8.100825" y2="44.063421875" width="0.508" layer="1"/>
-<wire x1="8.55621875" y1="35.799346875" x2="8.55621875" y2="34.417" width="0.508" layer="16"/>
+<wire x1="2.159" y1="45.339" x2="2.159" y2="43.942" width="0.508" layer="1"/>
+<wire x1="2.159" y1="45.339" x2="4.428715625" y2="47.608715625" width="0.508" layer="1"/>
+<wire x1="4.682715625" y1="47.608715625" x2="5.08" y2="47.608715625" width="0.508" layer="1"/>
+<wire x1="5.08" y1="47.608715625" x2="6.460715625" y2="47.608715625" width="0.508" layer="1"/>
+<wire x1="6.460715625" y1="47.608715625" x2="7.5940625" y2="47.608715625" width="0.508" layer="1"/>
+<wire x1="6.576825" y1="45.714421875" x2="6.576825" y2="45.71460625" width="0.508" layer="1"/>
+<wire x1="6.576825" y1="45.71460625" x2="5.571715625" y2="46.719715625" width="0.508" layer="1"/>
+<wire x1="8.55621875" y1="35.799346875" x2="8.55621875" y2="35.179" width="0.508" layer="16"/>
 <via x="8.55621875" y="25.4" extent="1-16" drill="0.3048"/>
-<wire x1="8.55621875" y1="25.4" x2="8.55621875" y2="34.417" width="0.508" layer="16"/>
+<wire x1="8.55621875" y1="25.4" x2="8.55621875" y2="35.179" width="0.508" layer="16"/>
 <wire x1="8.55621875" y1="25.4" x2="8.55621875" y2="24.003" width="0.508" layer="1"/>
 <wire x1="10.273" y1="22.28621875" x2="8.55621875" y2="24.003" width="0.508" layer="1"/>
 <wire x1="10.273" y1="22.28621875" x2="10.273" y2="13.97" width="0.508" layer="1"/>
-<wire x1="13.097284375" y1="39.099715625" x2="11.125" y2="41.072" width="0.508" layer="16"/>
-<wire x1="11.125" y1="41.072" x2="11.125" y2="41.275" width="0.508" layer="16"/>
-<wire x1="10.303284375" y1="34.05228125" x2="11.54071875" y2="34.05228125" width="0.254" layer="16"/>
-<wire x1="11.54071875" y1="34.05228125" x2="12.446" y2="33.147" width="0.254" layer="16"/>
-<wire x1="11.125" y1="46.101" x2="10.109" y2="46.101" width="0.508" layer="1"/>
-<wire x1="10.109" y1="46.101" x2="9.838715625" y2="45.830715625" width="0.508" layer="1"/>
-<wire x1="11.125" y1="46.101" x2="10.655" y2="46.571" width="0.508" layer="1"/>
-<wire x1="10.655" y1="46.571" x2="10.579" y2="46.571" width="0.508" layer="1"/>
-<wire x1="7.095715625" y1="45.068715625" x2="7.095715625" y2="45.085" width="0.508" layer="1"/>
-<wire x1="7.095715625" y1="45.085" x2="6.35" y2="45.830715625" width="0.508" layer="1"/>
-<wire x1="7.60371875" y1="34.94128125" x2="8.048221875" y2="35.385784375" width="0.508" layer="16"/>
+<wire x1="14.367284375" y1="39.099715625" x2="11.125" y2="42.342" width="0.508" layer="16"/>
+<wire x1="5.571715625" y1="46.719715625" x2="5.571715625" y2="47.21143125" width="0.508" layer="1"/>
+<wire x1="5.571715625" y1="47.21143125" x2="5.969" y2="47.608715625" width="0.508" layer="1"/>
+<wire x1="6.96871875" y1="34.30628125" x2="8.048221875" y2="35.385784375" width="0.508" layer="16"/>
 <wire x1="8.048221875" y1="35.385784375" x2="8.96978125" y2="35.385784375" width="0.508" layer="16"/>
-<wire x1="7.60371875" y1="34.94128125" x2="7.66721875" y2="35.00478125" width="0.508" layer="16"/>
-<wire x1="7.66721875" y1="35.00478125" x2="9.144" y2="35.00478125" width="0.508" layer="16"/>
-<wire x1="7.60371875" y1="34.94128125" x2="8.0319375" y2="34.94128125" width="0.508" layer="16"/>
-<wire x1="8.0319375" y1="34.94128125" x2="8.55621875" y2="34.417" width="0.508" layer="16"/>
-<wire x1="8.55621875" y1="34.417" x2="9.144" y2="35.00478125" width="0.508" layer="16"/>
-<wire x1="9.144" y1="35.00478125" x2="9.350784375" y2="35.00478125" width="0.508" layer="16"/>
+<wire x1="6.96871875" y1="34.30628125" x2="7.66721875" y2="35.00478125" width="0.508" layer="16"/>
+<wire x1="7.66721875" y1="35.00478125" x2="9.350784375" y2="35.00478125" width="0.508" layer="16"/>
+<wire x1="8.55621875" y1="35.179" x2="8.86639375" y2="35.489175" width="0.508" layer="16"/>
 <contactref element="U1" pad="34"/>
 <contactref element="U1" pad="14"/>
 <contactref element="U1" pad="24"/>
 <contactref element="U1" pad="44"/>
 <contactref element="U1" pad="7"/>
 <contactref element="U1" pad="2"/>
-<wire x1="-4.4196" y1="6.9596" x2="10.273" y2="13.97" width="0" layer="19" extent="1-1"/>
-<wire x1="-12.5476" y1="4.4196" x2="-4.4196" y2="6.9596" width="0" layer="19" extent="1-1"/>
-<wire x1="-15.9004" y1="9.3726" x2="-12.5476" y2="4.4196" width="0" layer="19" extent="1-1"/>
-<wire x1="-15.9004" y1="13.3604" x2="-15.9004" y2="9.3726" width="0" layer="19" extent="1-1"/>
-<wire x1="-14.1478" y1="15.9004" x2="-15.9004" y2="13.3604" width="0" layer="19" extent="1-1"/>
-<wire x1="-6.1722" y1="15.9004" x2="-14.1478" y2="15.9004" width="0" layer="19" extent="1-1"/>
+<wire x1="15.192784375" y1="39.925215625" x2="16.176215625" y2="39.925215625" width="0.254" layer="16"/>
+<wire x1="16.176215625" y1="39.925215625" x2="17.399" y2="41.148" width="0.254" layer="16"/>
+<via x="17.399" y="41.148" extent="1-16" drill="0.35"/>
+<wire x1="17.399" y1="41.148" x2="17.145" y2="41.148" width="0.254" layer="1"/>
+<wire x1="17.145" y1="41.148" x2="15.89305" y2="39.89605" width="0.254" layer="1"/>
+<wire x1="15.89305" y1="39.89605" x2="15.8471" y2="39.89605" width="0.254" layer="1"/>
+<wire x1="10.49" y1="47.625" x2="11.125" y2="48.26" width="0.508" layer="1"/>
+<wire x1="7.577778125" y1="47.625" x2="10.49" y2="47.625" width="0.508" layer="1"/>
+<wire x1="11.125" y1="47.625" x2="11.125" y2="48.26" width="0.508" layer="1"/>
+<wire x1="11.125" y1="47.625" x2="10.49" y2="47.625" width="0.508" layer="1"/>
+<wire x1="5.571715625" y1="46.719715625" x2="4.682715625" y2="47.608715625" width="0.508" layer="1"/>
+<wire x1="4.682715625" y1="47.608715625" x2="4.428715625" y2="47.608715625" width="0.508" layer="1"/>
+<wire x1="5.571715625" y1="46.719715625" x2="5.571715625" y2="47.117" width="0.508" layer="1"/>
+<wire x1="5.571715625" y1="47.117" x2="5.08" y2="47.608715625" width="0.508" layer="1"/>
+<wire x1="6.576825" y1="45.714421875" x2="7.550175" y2="45.714421875" width="0.3048" layer="1"/>
+<wire x1="7.550175" y1="45.714421875" x2="8.285721875" y2="44.978875" width="0.3048" layer="1"/>
+<wire x1="11.125" y1="42.342" x2="11.125" y2="41.275" width="0.508" layer="16"/>
+<wire x1="3.191284375" y1="38.11628125" x2="3.175003125" y2="38.1" width="0.254" layer="16"/>
+<wire x1="3.175003125" y1="38.1" x2="1.397" y2="38.1" width="0.254" layer="16"/>
+<via x="1.397" y="38.1" extent="1-16" drill="0.3048"/>
+<wire x1="2.646121875" y1="39.339275" x2="2.636275" y2="39.339275" width="0.254" layer="1"/>
+<wire x1="1.397" y1="38.1" x2="2.636275" y2="39.339275" width="0.254" layer="1"/>
+<wire x1="6.0227" y1="33.484146875" x2="4.826" y2="32.287446875" width="0.254" layer="1"/>
+<wire x1="4.826" y1="32.287446875" x2="4.826" y2="31.75" width="0.254" layer="1"/>
+<via x="4.826" y="31.75" extent="1-16" drill="0.3048"/>
+<wire x1="4.826" y1="31.75" x2="4.826" y2="32.1635625" width="0.254" layer="16"/>
+<wire x1="4.826" y1="32.1635625" x2="6.96871875" y2="34.30628125" width="0.254" layer="16"/>
+<wire x1="10.938284375" y1="33.29028125" x2="12.986565625" y2="31.242" width="0.254" layer="16"/>
+<wire x1="12.986565625" y1="31.242" x2="13.716" y2="31.242" width="0.254" layer="16"/>
+<via x="13.716" y="31.242" extent="1-16" drill="0.35"/>
+<wire x1="13.716" y1="31.242" x2="12.98463125" y2="31.242" width="0.254" layer="1"/>
+<wire x1="11.8957875" y1="32.352634375" x2="11.8957875" y2="32.33084375" width="0.254" layer="1"/>
+<wire x1="12.98463125" y1="31.242" x2="11.8957875" y2="32.33084375" width="0.254" layer="1"/>
+<wire x1="2.674603125" y1="35.753865625" x2="1.808140625" y2="35.753865625" width="0.254" layer="1"/>
+<wire x1="1.808140625" y1="35.753865625" x2="1.412265625" y2="36.149740625" width="0.254" layer="1"/>
+<wire x1="3.202896875" y1="36.303946875" x2="3.202896875" y2="36.282159375" width="0.254" layer="1"/>
+<wire x1="3.202896875" y1="36.282159375" x2="2.674603125" y2="35.753865625" width="0.254" layer="1"/>
+<wire x1="1.412265625" y1="38.084734375" x2="1.397" y2="38.1" width="0.254" layer="1"/>
+<wire x1="1.412265625" y1="36.149740625" x2="1.412265625" y2="38.084734375" width="0.254" layer="1"/>
 </signal>
 <signal name="N$3">
 <contactref element="SW00" pad="2A"/>
@@ -1181,16 +1183,14 @@ design rules under a new name.</description>
 <wire x1="6.955" y1="10.398" x2="6.955" y2="12.402" width="0.254" layer="1"/>
 <contactref element="U1" pad="13"/>
 <contactref element="R1" pad="2"/>
-<wire x1="6.955" y1="12.402" x2="8.523" y2="13.97" width="0" layer="19" extent="1-1"/>
-<wire x1="-13.3604" y1="4.4196" x2="6.955" y2="10.398" width="0" layer="19" extent="1-1"/>
+<wire x1="6.955" y1="12.402" x2="8.523" y2="13.97" width="0.254" layer="1"/>
+<wire x1="8.523" y1="13.97" x2="11.32105" y2="31.777896875" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="UCAP">
 <contactref element="C8" pad="1"/>
-<wire x1="5.958528125" y1="34.5666" x2="5.9506125" y2="34.5666" width="0.254" layer="1"/>
-<wire x1="5.9506125" y1="34.5666" x2="4.826" y2="33.4419875" width="0.254" layer="1"/>
-<wire x1="4.826" y1="33.4419875" x2="4.826" y2="32.625" width="0.254" layer="1"/>
+<wire x1="3.556" y1="32.131" x2="3.556" y2="31.355" width="0.254" layer="1"/>
 <contactref element="U1" pad="6"/>
-<wire x1="-15.9004" y1="10.16" x2="4.826" y2="32.625" width="0" layer="19" extent="1-1"/>
+<wire x1="5.465921875" y1="34.040921875" x2="3.556" y2="32.131" width="0.254" layer="1"/>
 </signal>
 <signal name="N$5">
 <contactref element="USB1" pad="D+"/>
@@ -1201,21 +1201,18 @@ design rules under a new name.</description>
 </signal>
 <signal name="N$6">
 <contactref element="R4" pad="2"/>
-<wire x1="7.874" y1="51.195" x2="7.874" y2="47.752" width="0.254" layer="1"/>
-<via x="7.874" y="47.752" extent="1-16" drill="0.3048"/>
-<via x="3.81" y="36.195" extent="1-16" drill="0.3048"/>
-<wire x1="7.874" y1="47.752" x2="7.874" y2="39.862196875" width="0.254" layer="16"/>
+<wire x1="7.874" y1="51.195" x2="7.874" y2="49.149" width="0.254" layer="1"/>
+<via x="7.874" y="49.149" extent="1-16" drill="0.3048"/>
+<wire x1="7.874" y1="49.149" x2="7.874" y2="39.862196875" width="0.254" layer="16"/>
 <wire x1="4.833896875" y1="36.82209375" x2="7.874" y2="39.862196875" width="0.254" layer="16"/>
-<wire x1="5.985934375" y1="36.815825" x2="5.6141375" y2="36.44918125" width="0.254" layer="1"/>
-<wire x1="5.6141375" y1="36.44918125" x2="5.60964375" y2="36.4492125" width="0.254" layer="1"/>
-<wire x1="5.60964375" y1="36.4492125" x2="5.42944375" y2="36.2715125" width="0.254" layer="1"/>
-<wire x1="5.42944375" y1="36.2715125" x2="4.908403125" y2="36.275140625" width="0.254" layer="1"/>
-<wire x1="4.908403125" y1="36.275140625" x2="3.729859375" y2="36.275140625" width="0.254" layer="1"/>
-<wire x1="3.729859375" y1="36.275140625" x2="3.81" y2="36.195" width="0.254" layer="1"/>
-<wire x1="3.81" y1="36.195" x2="4.206778125" y2="36.195" width="0.254" layer="16"/>
-<wire x1="4.833896875" y1="36.82209375" x2="4.206778125" y2="36.195" width="0.254" layer="16"/>
+<wire x1="4.833896875" y1="36.82209375" x2="2.68271875" y2="34.671" width="0.254" layer="16"/>
 <contactref element="U1" pad="3"/>
-<wire x1="-15.9004" y1="12.5476" x2="3.729859375" y2="36.275140625" width="0" layer="19" extent="1-1"/>
+<via x="1.778" y="34.671" extent="1-16" drill="0.3048"/>
+<wire x1="2.723378125" y1="34.689090625" x2="3.763496875" y2="35.729209375" width="0.254" layer="1"/>
+<wire x1="3.763496875" y1="35.729209375" x2="3.777634375" y2="35.729209375" width="0.254" layer="1"/>
+<wire x1="1.778" y1="34.671" x2="1.796090625" y2="34.689090625" width="0.254" layer="1"/>
+<wire x1="1.796090625" y1="34.689090625" x2="2.723378125" y2="34.689090625" width="0.254" layer="1"/>
+<wire x1="2.68271875" y1="34.671" x2="1.778" y2="34.671" width="0.254" layer="16"/>
 </signal>
 <signal name="N$7">
 <contactref element="USB1" pad="D-"/>
@@ -1226,17 +1223,16 @@ design rules under a new name.</description>
 </signal>
 <signal name="N$8">
 <contactref element="R3" pad="2"/>
-<wire x1="9.525" y1="51.195" x2="9.525" y2="47.752" width="0.254" layer="1"/>
-<via x="9.525" y="47.752" extent="1-16" drill="0.3048"/>
-<wire x1="9.525" y1="47.752" x2="9.525" y2="40.475021875" width="0.254" layer="16"/>
-<via x="4.572" y="35.306" extent="1-16" drill="0.3048"/>
-<wire x1="4.97816875" y1="35.71216875" x2="4.572" y2="35.306" width="0.254" layer="1"/>
-<wire x1="6.437559375" y1="36.4333625" x2="5.716365625" y2="35.71216875" width="0.254" layer="1"/>
-<wire x1="4.97816875" y1="35.71216875" x2="5.716365625" y2="35.71216875" width="0.254" layer="1"/>
-<wire x1="4.572" y1="35.306" x2="4.57198125" y2="35.522003125" width="0.254" layer="16"/>
-<wire x1="9.525" y1="40.475021875" x2="4.57198125" y2="35.522003125" width="0.254" layer="16"/>
+<wire x1="9.525" y1="51.195" x2="9.525" y2="49.149" width="0.254" layer="1"/>
+<via x="9.525" y="49.149" extent="1-16" drill="0.3048"/>
+<wire x1="9.525" y1="49.149" x2="9.525" y2="40.729021875" width="0.254" layer="16"/>
+<wire x1="9.525" y1="40.729021875" x2="2.92094375" y2="34.124965625" width="0.254" layer="16"/>
 <contactref element="U1" pad="4"/>
-<wire x1="-15.9004" y1="11.7602" x2="4.572" y2="35.306" width="0" layer="19" extent="1-1"/>
+<wire x1="2.92094375" y1="34.124965625" x2="2.921" y2="33.401" width="0.254" layer="16"/>
+<via x="2.921" y="33.401" extent="1-16" drill="0.3048"/>
+<wire x1="2.921" y1="33.401" x2="2.921" y2="33.782" width="0.254" layer="1"/>
+<wire x1="4.311434375" y1="35.172434375" x2="2.921" y2="33.782" width="0.254" layer="1"/>
+<wire x1="4.311434375" y1="35.172434375" x2="4.334409375" y2="35.172434375" width="0.254" layer="1"/>
 </signal>
 <signal name="N$9">
 <contactref element="SW01" pad="MX2"/>
@@ -1264,16 +1260,15 @@ design rules under a new name.</description>
 <wire x1="63.461" y1="29.347925" x2="63.461" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="63.461" y1="27.802075" x2="62.865" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="62.865" y1="27.206075" x2="62.865" y2="12.065" width="0.254" layer="16"/>
-<wire x1="13.041984375" y1="42.291" x2="17.272" y2="42.291" width="0.254" layer="1"/>
-<wire x1="17.272" y1="42.291" x2="18.542" y2="43.561" width="0.254" layer="1"/>
 <wire x1="18.542" y1="71.501" x2="20.701" y2="73.66" width="0.254" layer="1"/>
 <wire x1="20.701" y1="73.66" x2="60.96" y2="73.66" width="0.254" layer="1"/>
-<via x="60.96" y="73.66" extent="1-16" drill="0.35"/>
+<via x="60.96" y="73.66" extent="1-16" drill="0.3048"/>
 <wire x1="60.96" y1="73.66" x2="62.865" y2="71.755" width="0.254" layer="16"/>
 <wire x1="62.865" y1="71.755" x2="62.865" y2="69.215" width="0.254" layer="16"/>
-<wire x1="18.542" y1="43.561" x2="18.542" y2="71.501" width="0.254" layer="1"/>
+<wire x1="18.542" y1="48.26" x2="18.542" y2="71.501" width="0.254" layer="1"/>
 <contactref element="U1" pad="29"/>
-<wire x1="-4.4196" y1="10.9474" x2="13.041984375" y2="42.291" width="0" layer="19" extent="1-1"/>
+<wire x1="13.027296875" y1="42.71585" x2="13.027296875" y2="42.745296875" width="0.254" layer="1"/>
+<wire x1="13.027296875" y1="42.745296875" x2="18.542" y2="48.26" width="0.254" layer="1"/>
 </signal>
 <signal name="N$12">
 <contactref element="SW02" pad="MX2"/>
@@ -1282,24 +1277,24 @@ design rules under a new name.</description>
 <wire x1="40.64" y1="14.605" x2="39.37" y2="13.335" width="0.254" layer="1"/>
 </signal>
 <signal name="N$14">
-<wire x1="13.96534375" y1="40.386" x2="15.875" y2="40.386" width="0.254" layer="1"/>
-<wire x1="15.875" y1="40.386" x2="17.78" y2="38.481" width="0.254" layer="1"/>
+<wire x1="18.034" y1="42.164" x2="18.923" y2="41.275" width="0.254" layer="1"/>
 <contactref element="D1" pad="C"/>
 <contactref element="D2" pad="C"/>
 <contactref element="D3" pad="C"/>
-<wire x1="17.78" y1="3.81" x2="20.32" y2="1.27" width="0.254" layer="1"/>
+<wire x1="18.923" y1="2.667" x2="20.32" y2="1.27" width="0.254" layer="1"/>
 <wire x1="20.32" y1="1.27" x2="38.1" y2="1.27" width="0.254" layer="1"/>
 <wire x1="38.1" y1="1.27" x2="55.88" y2="1.27" width="0.254" layer="1"/>
 <wire x1="55.88" y1="1.27" x2="57.15" y2="2.54" width="0.254" layer="1"/>
 <wire x1="57.15" y1="2.54" x2="57.15" y2="5.715" width="0.254" layer="1"/>
-<wire x1="17.78" y1="38.481" x2="17.78" y2="3.81" width="0.254" layer="1"/>
+<wire x1="18.923" y1="41.275" x2="18.923" y2="2.667" width="0.254" layer="1"/>
 <wire x1="36.83" y1="5.715" x2="36.83" y2="3.81" width="0.254" layer="1"/>
 <wire x1="36.83" y1="3.81" x2="38.1" y2="2.54" width="0.254" layer="1"/>
 <wire x1="38.1" y1="2.54" x2="39.37" y2="3.81" width="0.254" layer="1"/>
 <wire x1="39.37" y1="3.81" x2="39.37" y2="5.715" width="0.254" layer="1"/>
 <wire x1="38.1" y1="2.54" x2="38.1" y2="1.27" width="0.254" layer="1"/>
 <contactref element="U1" pad="25"/>
-<wire x1="-4.4196" y1="7.7724" x2="17.78" y2="3.81" width="0" layer="19" extent="1-1"/>
+<wire x1="15.2723625" y1="40.4707875" x2="16.965575" y2="42.164" width="0.254" layer="1"/>
+<wire x1="16.965575" y1="42.164" x2="18.034" y2="42.164" width="0.254" layer="1"/>
 </signal>
 <signal name="N$15">
 <contactref element="SW03" pad="MX2"/>
@@ -1327,15 +1322,13 @@ design rules under a new name.</description>
 <wire x1="25.361" y1="29.347925" x2="25.361" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="25.361" y1="27.802075" x2="24.765" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="24.765" y1="27.206075" x2="24.765" y2="12.065" width="0.254" layer="16"/>
-<wire x1="12.64380625" y1="43.307" x2="16.637" y2="43.307" width="0.254" layer="1"/>
-<wire x1="16.637" y1="43.307" x2="17.399" y2="44.069" width="0.254" layer="1"/>
-<wire x1="17.399" y1="44.069" x2="17.399" y2="72.644" width="0.254" layer="1"/>
+<wire x1="11.8957875" y1="43.8473625" x2="17.399" y2="49.350575" width="0.254" layer="1"/>
+<wire x1="17.399" y1="49.350575" x2="17.399" y2="72.644" width="0.254" layer="1"/>
 <wire x1="17.399" y1="72.644" x2="18.542" y2="73.787" width="0.254" layer="1"/>
-<via x="18.542" y="73.787" extent="1-16" drill="0.35"/>
+<via x="18.542" y="73.787" extent="1-16" drill="0.3048"/>
 <wire x1="18.542" y1="73.787" x2="23.114" y2="69.215" width="0.254" layer="16"/>
 <wire x1="23.114" y1="69.215" x2="24.765" y2="69.215" width="0.254" layer="16"/>
 <contactref element="U1" pad="31"/>
-<wire x1="-4.4196" y1="12.5476" x2="24.765" y2="12.065" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$18">
 <contactref element="SW04" pad="MX2"/>
@@ -1356,25 +1349,24 @@ design rules under a new name.</description>
 <wire x1="35.56" y1="33.655" x2="36.83" y2="32.385" width="0.254" layer="1"/>
 </signal>
 <signal name="N$26">
-<wire x1="12.712990625" y1="39.740184375" x2="13.76520625" y2="40.7924" width="0.254" layer="1"/>
-<wire x1="16.1036" y1="40.7924" x2="18.288" y2="38.608" width="0.254" layer="1"/>
-<wire x1="13.76520625" y1="40.7924" x2="16.1036" y2="40.7924" width="0.254" layer="1"/>
 <contactref element="D4" pad="C"/>
 <contactref element="D5" pad="C"/>
 <contactref element="D6" pad="C"/>
-<wire x1="18.288" y1="22.352" x2="20.32" y2="20.32" width="0.254" layer="1"/>
-<wire x1="20.32" y1="20.32" x2="38.1" y2="20.32" width="0.254" layer="1"/>
 <wire x1="38.1" y1="20.32" x2="55.88" y2="20.32" width="0.254" layer="1"/>
 <wire x1="55.88" y1="20.32" x2="57.15" y2="21.59" width="0.254" layer="1"/>
 <wire x1="57.15" y1="21.59" x2="57.15" y2="24.765" width="0.254" layer="1"/>
-<wire x1="18.288" y1="38.608" x2="18.288" y2="22.352" width="0.254" layer="1"/>
+<wire x1="19.558" y1="41.783" x2="19.558" y2="21.59" width="0.254" layer="1"/>
 <wire x1="36.83" y1="24.765" x2="36.83" y2="22.86" width="0.254" layer="1"/>
 <wire x1="36.83" y1="22.86" x2="38.1" y2="21.59" width="0.254" layer="1"/>
 <wire x1="38.1" y1="21.59" x2="38.1" y2="20.32" width="0.254" layer="1"/>
 <wire x1="39.37" y1="24.765" x2="39.37" y2="22.86" width="0.254" layer="1"/>
 <wire x1="39.37" y1="22.86" x2="38.1" y2="21.59" width="0.254" layer="1"/>
 <contactref element="U1" pad="26"/>
-<wire x1="-4.4196" y1="8.5598" x2="18.288" y2="22.352" width="0" layer="19" extent="1-1"/>
+<wire x1="18.3896" y1="42.9514" x2="16.639425" y2="42.9514" width="0.254" layer="1"/>
+<wire x1="16.639425" y1="42.9514" x2="14.7155875" y2="41.0275625" width="0.254" layer="1"/>
+<wire x1="19.558" y1="41.783" x2="18.3896" y2="42.9514" width="0.254" layer="1"/>
+<wire x1="19.558" y1="21.59" x2="20.828" y2="20.32" width="0.254" layer="1"/>
+<wire x1="20.828" y1="20.32" x2="38.1" y2="20.32" width="0.254" layer="1"/>
 </signal>
 <signal name="N$27">
 <contactref element="SW07" pad="MX2"/>
@@ -1392,19 +1384,19 @@ design rules under a new name.</description>
 <contactref element="D9" pad="C"/>
 <contactref element="D8" pad="C"/>
 <contactref element="D7" pad="C"/>
-<wire x1="19.7612" y1="41.1988" x2="21.59" y2="39.37" width="0.254" layer="1"/>
-<wire x1="21.59" y1="39.37" x2="38.1" y2="39.37" width="0.254" layer="1"/>
+<wire x1="23.114" y1="39.37" x2="38.1" y2="39.37" width="0.254" layer="1"/>
 <wire x1="38.1" y1="39.37" x2="55.88" y2="39.37" width="0.254" layer="1"/>
 <wire x1="55.88" y1="39.37" x2="57.15" y2="40.64" width="0.254" layer="1"/>
 <wire x1="57.15" y1="40.64" x2="57.15" y2="43.815" width="0.254" layer="1"/>
-<wire x1="13.363965625" y1="41.1988" x2="19.7612" y2="41.1988" width="0.254" layer="1"/>
 <wire x1="36.83" y1="43.815" x2="36.83" y2="41.91" width="0.254" layer="1"/>
 <wire x1="36.83" y1="41.91" x2="38.1" y2="40.64" width="0.254" layer="1"/>
 <wire x1="38.1" y1="40.64" x2="39.37" y2="41.91" width="0.254" layer="1"/>
 <wire x1="39.37" y1="41.91" x2="39.37" y2="43.815" width="0.254" layer="1"/>
 <wire x1="38.1" y1="40.64" x2="38.1" y2="39.37" width="0.254" layer="1"/>
 <contactref element="U1" pad="27"/>
-<wire x1="-4.4196" y1="9.3726" x2="13.363965625" y2="41.1988" width="0" layer="19" extent="1-1"/>
+<wire x1="14.14085" y1="41.602296875" x2="16.480553125" y2="43.942" width="0.254" layer="1"/>
+<wire x1="16.480553125" y1="43.942" x2="18.542" y2="43.942" width="0.254" layer="1"/>
+<wire x1="18.542" y1="43.942" x2="23.114" y2="39.37" width="0.254" layer="1"/>
 </signal>
 <signal name="N$33">
 <contactref element="SW09" pad="MX2"/>
@@ -1420,10 +1412,8 @@ design rules under a new name.</description>
 <wire x1="57.15" y1="70.485" x2="57.15" y2="70.4354" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$38">
-<wire x1="17.526" y1="41.656" x2="19.177" y2="43.307" width="0.254" layer="1"/>
-<wire x1="13.114071875" y1="41.656" x2="17.526" y2="41.656" width="0.254" layer="1"/>
 <wire x1="55.88" y1="58.42" x2="57.15" y2="59.69" width="0.254" layer="1"/>
-<wire x1="19.177" y1="43.307" x2="19.177" y2="57.023" width="0.254" layer="1"/>
+<wire x1="19.177" y1="47.752" x2="19.177" y2="57.023" width="0.254" layer="1"/>
 <wire x1="19.177" y1="57.023" x2="20.574" y2="58.42" width="0.254" layer="1"/>
 <contactref element="D10" pad="C"/>
 <contactref element="D11" pad="C"/>
@@ -1437,7 +1427,7 @@ design rules under a new name.</description>
 <wire x1="38.1" y1="59.69" x2="38.1" y2="58.42" width="0.254" layer="1"/>
 <wire x1="20.574" y1="58.42" x2="38.1" y2="58.42" width="0.254" layer="1"/>
 <contactref element="U1" pad="28"/>
-<wire x1="-4.4196" y1="10.16" x2="13.114071875" y2="41.656" width="0" layer="19" extent="1-1"/>
+<wire x1="13.584075" y1="42.159075" x2="19.177" y2="47.752" width="0.254" layer="1"/>
 </signal>
 <signal name="N$39">
 <contactref element="SW11" pad="MX2"/>
@@ -1466,16 +1456,15 @@ design rules under a new name.</description>
 <wire x1="44.411" y1="29.347925" x2="44.411" y2="27.802075" width="0.254" layer="16"/>
 <wire x1="44.411" y1="27.802075" x2="43.815" y2="27.206075" width="0.254" layer="16"/>
 <wire x1="43.815" y1="27.206075" x2="43.815" y2="12.065" width="0.254" layer="16"/>
-<wire x1="12.84289375" y1="42.799" x2="16.891" y2="42.799" width="0.254" layer="1"/>
 <wire x1="18.0086" y1="72.0503375" x2="20.2786625" y2="74.3204" width="0.254" layer="1"/>
-<via x="43.815" y="74.3176" extent="1-16" drill="0.35"/>
+<via x="43.815" y="74.3176" extent="1-16" drill="0.3048"/>
 <wire x1="43.815" y1="74.3176" x2="43.815" y2="69.215" width="0.254" layer="16"/>
-<wire x1="16.891" y1="42.799" x2="18.0086" y2="43.9166" width="0.254" layer="1"/>
-<wire x1="18.0086" y1="43.9166" x2="18.0086" y2="72.0503375" width="0.254" layer="1"/>
+<wire x1="18.0086" y1="48.8696" x2="18.0086" y2="72.0503375" width="0.254" layer="1"/>
 <wire x1="20.2786625" y1="74.3204" x2="43.8122" y2="74.3204" width="0.254" layer="1"/>
 <wire x1="43.8122" y1="74.3204" x2="43.815" y2="74.3176" width="0.254" layer="1"/>
 <contactref element="U1" pad="30"/>
-<wire x1="-4.4196" y1="11.7602" x2="12.84289375" y2="42.799" width="0" layer="19" extent="1-1"/>
+<wire x1="12.4525625" y1="43.2905875" x2="12.4525625" y2="43.3135625" width="0.254" layer="1"/>
+<wire x1="12.4525625" y1="43.3135625" x2="18.0086" y2="48.8696" width="0.254" layer="1"/>
 </signal>
 <signal name="N$42">
 <contactref element="SW12" pad="MX2"/>
@@ -1486,7 +1475,8 @@ design rules under a new name.</description>
 <signal name="N$4">
 <contactref element="U1" pad="33"/>
 <contactref element="R2" pad="2"/>
-<wire x1="-4.4196" y1="14.1478" x2="12.446" y2="51.195" width="0" layer="19" extent="1-1"/>
+<wire x1="10.764275" y1="44.978875" x2="12.446" y2="46.6606" width="0.254" layer="1"/>
+<wire x1="12.446" y1="46.6606" x2="12.446" y2="51.195" width="0.254" layer="1"/>
 </signal>
 <signal name="N$11">
 <contactref element="USB1" pad="SHIELD@1"/>
@@ -1517,8 +1507,8 @@ design rules under a new name.</description>
 <contactref element="C6" pad="2"/>
 <contactref element="C7" pad="2"/>
 <contactref element="C9" pad="2"/>
-<wire x1="11.54071875" y1="35.289715625" x2="11.54071875" y2="34.94128125" width="0.254" layer="16"/>
-<wire x1="5.85828125" y1="43.83128125" x2="5.85828125" y2="43.391165625" width="0.254" layer="1"/>
+<wire x1="12.17571875" y1="34.527715625" x2="12.17571875" y2="34.17928125" width="0.254" layer="16"/>
+<wire x1="4.33428125" y1="45.48228125" x2="4.33428125" y2="45.042165625" width="0.254" layer="1"/>
 <contactref element="Y1" pad="2"/>
 <contactref element="Y1" pad="4"/>
 <contactref element="C1" pad="1"/>
@@ -1526,21 +1516,16 @@ design rules under a new name.</description>
 <contactref element="SW00" pad="1A"/>
 <contactref element="SW00" pad="1B"/>
 <contactref element="R2" pad="1"/>
-<wire x1="10.661" y1="29.5" x2="8.686" y2="29.5" width="0.254" layer="1"/>
-<wire x1="8.636" y1="29.45" x2="8.686" y2="29.5" width="0.254" layer="1"/>
-<wire x1="11.111" y1="29.5" x2="10.661" y2="29.5" width="0.254" layer="1"/>
-<wire x1="12.961" y1="27.65" x2="13.011" y2="27.7" width="0.254" layer="1"/>
+<wire x1="12.693" y1="28.484" x2="10.718" y2="28.484" width="0.254" layer="1"/>
+<wire x1="10.668" y1="28.434" x2="10.718" y2="28.484" width="0.254" layer="1"/>
+<wire x1="13.143" y1="28.484" x2="12.693" y2="28.484" width="0.254" layer="1"/>
+<wire x1="14.993" y1="26.634" x2="15.043" y2="26.684" width="0.254" layer="1"/>
 <wire x1="13.335" y1="63.008" x2="13.335" y2="61.341" width="0.254" layer="1"/>
 <via x="13.335" y="61.341" extent="1-16" drill="0.3048"/>
-<wire x1="14.986" y1="27.7" x2="14.986" y2="25.4" width="0.254" layer="1"/>
-<via x="14.986" y="25.4" extent="1-16" drill="0.3048"/>
-<wire x1="4.826" y1="30.875" x2="4.826" y2="29.21" width="0.254" layer="1"/>
-<via x="4.826" y="29.21" extent="1-16" drill="0.3048"/>
-<wire x1="8.50285625" y1="41.889590625" x2="8.127821875" y2="42.264625" width="0.254" layer="1"/>
-<wire x1="7.425121875" y1="42.264625" x2="6.885171875" y2="42.804575" width="0.254" layer="1"/>
-<wire x1="8.127821875" y1="42.264625" x2="7.425121875" y2="42.264625" width="0.254" layer="1"/>
-<wire x1="8.636" y1="37.951165625" x2="8.636" y2="38.1" width="0.254" layer="1"/>
-<wire x1="10.16" y1="37.41474375" x2="10.23674375" y2="37.338" width="0.254" layer="1"/>
+<wire x1="17.018" y1="26.684" x2="17.018" y2="24.384" width="0.254" layer="1"/>
+<via x="17.018" y="24.384" extent="1-16" drill="0.3048"/>
+<wire x1="3.556" y1="29.605" x2="3.556" y2="27.94" width="0.254" layer="1"/>
+<via x="3.556" y="27.94" extent="1-16" drill="0.3048"/>
 <wire x1="7.925" y1="67.55" x2="7.925" y2="65.202" width="0.508" layer="1"/>
 <wire x1="7.925" y1="65.202" x2="7.874" y2="65.151" width="0.508" layer="1"/>
 <polygon width="0.254" layer="1">
@@ -1555,34 +1540,11 @@ design rules under a new name.</description>
 <vertex x="77.47" y="-1.27"/>
 <vertex x="-1.27" y="-1.27"/>
 </polygon>
-<via x="14.986" y="35.687" extent="1-16" drill="0.3048"/>
 <contactref element="U1" pad="15"/>
 <contactref element="U1" pad="23"/>
 <contactref element="U1" pad="35"/>
 <contactref element="U1" pad="43"/>
 <contactref element="U1" pad="5"/>
-<wire x1="7.925" y1="65.202" x2="13.335" y2="63.008" width="0" layer="19" extent="1-1"/>
-<wire x1="12.446" y1="52.945" x2="13.335" y2="61.341" width="0" layer="19" extent="1-1"/>
-<wire x1="5.85828125" y1="43.83128125" x2="12.446" y2="52.945" width="0" layer="19" extent="1-1"/>
-<wire x1="6.885171875" y1="42.804575" x2="5.85828125" y2="43.391165625" width="0" layer="19" extent="1-1"/>
-<wire x1="6.20671875" y1="39.480715625" x2="7.425121875" y2="42.264625" width="0" layer="19" extent="1-16"/>
-<wire x1="8.636" y1="38.1" x2="6.20671875" y2="39.480715625" width="0" layer="19" extent="1-16"/>
-<wire x1="10.16" y1="37.41474375" x2="8.636" y2="37.951165625" width="0" layer="19" extent="1-1"/>
-<wire x1="11.54071875" y1="35.289715625" x2="10.23674375" y2="37.338" width="0" layer="19" extent="1-16"/>
-<wire x1="6.366284375" y1="36.178715625" x2="8.636" y2="37.951165625" width="0" layer="19" extent="1-16"/>
-<wire x1="14.986" y1="35.687" x2="11.54071875" y2="35.289715625" width="0" layer="19" extent="16-16"/>
-<wire x1="14.33471875" y1="37.86228125" x2="14.986" y2="35.687" width="0" layer="19" extent="16-16"/>
-<wire x1="11.111" y1="29.5" x2="11.54071875" y2="34.94128125" width="0" layer="19" extent="1-16"/>
-<wire x1="12.961" y1="27.65" x2="11.111" y2="29.5" width="0" layer="19" extent="1-1"/>
-<wire x1="14.986" y1="27.7" x2="13.011" y2="27.7" width="0" layer="19" extent="1-1"/>
-<wire x1="4.826" y1="29.21" x2="8.636" y2="29.45" width="0" layer="19" extent="1-1"/>
-<wire x1="12.095" y1="8.398" x2="14.986" y2="25.4" width="0" layer="19" extent="1-1"/>
-<wire x1="6.955" y1="8.398" x2="12.095" y2="8.398" width="0" layer="19" extent="1-1"/>
-<wire x1="-4.4196" y1="6.1722" x2="6.955" y2="8.398" width="0" layer="19" extent="1-1"/>
-<wire x1="-11.7602" y1="4.4196" x2="-4.4196" y2="6.1722" width="0" layer="19" extent="1-1"/>
-<wire x1="-15.9004" y1="10.9474" x2="-11.7602" y2="4.4196" width="0" layer="19" extent="1-1"/>
-<wire x1="-13.3604" y1="15.9004" x2="-15.9004" y2="10.9474" width="0" layer="19" extent="1-1"/>
-<wire x1="-6.9596" y1="15.9004" x2="-13.3604" y2="15.9004" width="0" layer="19" extent="1-1"/>
 </signal>
 </signals>
 <mfgpreviewcolors>

--- a/PCB/MacroPad.cam
+++ b/PCB/MacroPad.cam
@@ -1,0 +1,291 @@
+{
+    "author": {
+        "email": "tornquist@live.com",
+        "name": "Nathan Tornquist"
+    },
+    "description": {
+        "EN": "EAGLE default 2 layer CAM job with additional vias output."
+    },
+    "output_type": "zip",
+    "outputs": [
+        {
+            "filename_prefix": "CAMOutputs/GerberFiles",
+            "format_specifier": {
+                "decimal": 4,
+                "integer": 3
+            },
+            "generate_job_file": true,
+            "output_type": "gerber",
+            "outputs": [
+                {
+                    "advanced_options": {
+                        "mirror": false,
+                        "offset_x": 0,
+                        "offset_y": 0,
+                        "rotate": false,
+                        "upside_down": false
+                    },
+                    "board_outline": false,
+                    "config": {
+                        "file_function": "Copper",
+                        "layer": 1,
+                        "layer_details": "mixed",
+                        "layer_type": "top"
+                    },
+                    "filename_format": "%PREFIX/copper_top.gbr",
+                    "layers": [
+                        1,
+                        17,
+                        18
+                    ],
+                    "name": "Top Copper",
+                    "polarity": "positive",
+                    "type": "gerber_layer"
+                },
+                {
+                    "advanced_options": {
+                        "mirror": false,
+                        "offset_x": 0,
+                        "offset_y": 0,
+                        "rotate": false,
+                        "upside_down": false
+                    },
+                    "board_outline": false,
+                    "config": {
+                        "file_function": "Copper",
+                        "layer": 2,
+                        "layer_details": "mixed",
+                        "layer_type": "bottom"
+                    },
+                    "filename_format": "%PREFIX/copper_bottom.gbr",
+                    "layers": [
+                        16,
+                        17,
+                        18
+                    ],
+                    "name": "Bottom Copper",
+                    "polarity": "positive",
+                    "type": "gerber_layer"
+                },
+                {
+                    "advanced_options": {
+                        "mirror": false,
+                        "offset_x": 0,
+                        "offset_y": 0,
+                        "rotate": false,
+                        "upside_down": false
+                    },
+                    "board_outline": true,
+                    "config": {
+                        "file_function": "Profile",
+                        "plating": "non-plated"
+                    },
+                    "filename_format": "%PREFIX/profile.gbr",
+                    "layers": [
+                    ],
+                    "milling": true,
+                    "polarity": "positive",
+                    "type": "gerber_layer"
+                },
+                {
+                    "advanced_options": {
+                        "mirror": false,
+                        "offset_x": 0,
+                        "offset_y": 0,
+                        "rotate": false,
+                        "upside_down": false
+                    },
+                    "board_outline": false,
+                    "config": {
+                        "file_function": "Soldermask",
+                        "index": 1,
+                        "layer_type": "top"
+                    },
+                    "filename_format": "%PREFIX/soldermask_top.gbr",
+                    "layers": [
+                        29
+                    ],
+                    "name": "Soldermask Top",
+                    "polarity": "positive",
+                    "type": "gerber_layer"
+                },
+                {
+                    "advanced_options": {
+                        "mirror": false,
+                        "offset_x": 0,
+                        "offset_y": 0,
+                        "rotate": false,
+                        "upside_down": false
+                    },
+                    "board_outline": false,
+                    "config": {
+                        "file_function": "Soldermask",
+                        "index": 1,
+                        "layer_type": "bottom"
+                    },
+                    "filename_format": "%PREFIX/soldermask_bottom.gbr",
+                    "layers": [
+                        30
+                    ],
+                    "name": "Soldermask Bottom",
+                    "polarity": "positive",
+                    "type": "gerber_layer"
+                },
+                {
+                    "advanced_options": {
+                        "mirror": false,
+                        "offset_x": 0,
+                        "offset_y": 0,
+                        "rotate": false,
+                        "upside_down": false
+                    },
+                    "board_outline": false,
+                    "config": {
+                        "file_function": "Paste",
+                        "layer_type": "top"
+                    },
+                    "filename_format": "%PREFIX/solderpaste_top.gbr",
+                    "layers": [
+                        31
+                    ],
+                    "milling": false,
+                    "name": "Solderpaste Top",
+                    "polarity": "positive",
+                    "type": "gerber_layer"
+                },
+                {
+                    "advanced_options": {
+                        "mirror": false,
+                        "offset_x": 0,
+                        "offset_y": 0,
+                        "rotate": false,
+                        "upside_down": false
+                    },
+                    "board_outline": false,
+                    "config": {
+                        "file_function": "Paste",
+                        "layer_type": "bottom"
+                    },
+                    "filename_format": "%PREFIX/solderpaste_bottom.gbr",
+                    "layers": [
+                        32
+                    ],
+                    "milling": false,
+                    "name": "Solderpaste Bottom",
+                    "polarity": "positive",
+                    "type": "gerber_layer"
+                },
+                {
+                    "advanced_options": {
+                        "mirror": false,
+                        "offset_x": 0,
+                        "offset_y": 0,
+                        "rotate": false,
+                        "upside_down": false
+                    },
+                    "board_outline": false,
+                    "config": {
+                        "file_function": "Legend",
+                        "index": 1,
+                        "layer_type": "top"
+                    },
+                    "filename_format": "%PREFIX/silkscreen_top.gbr",
+                    "layers": [
+                        21,
+                        25
+                    ],
+                    "milling": false,
+                    "name": "Silkscreen Top",
+                    "polarity": "positive",
+                    "type": "gerber_layer"
+                },
+                {
+                    "advanced_options": {
+                        "mirror": false,
+                        "offset_x": 0,
+                        "offset_y": 0,
+                        "rotate": false,
+                        "upside_down": false
+                    },
+                    "board_outline": false,
+                    "config": {
+                        "file_function": "Legend",
+                        "index": 1,
+                        "layer_type": "bottom"
+                    },
+                    "filename_format": "%PREFIX/silkscreen_bottom.gbr",
+                    "layers": [
+                        22,
+                        26
+                    ],
+                    "milling": false,
+                    "name": "Silkscreen Bottom",
+                    "polarity": "positive",
+                    "type": "gerber_layer"
+                },
+                {
+                    "board_outline": false,
+                    "config": {
+                        "description": "Vias",
+                        "file_function": "Other"
+                    },
+                    "filename_format": "%PREFIX/%FF.gbr",
+                    "layers": [
+                        18
+                    ],
+                    "milling": false,
+                    "name": "Vias",
+                    "polarity": "positive",
+                    "type": "gerber_layer"
+                }
+            ],
+            "version": "RS274X"
+        },
+        {
+            "filename_prefix": "CAMOutputs/DrillFiles",
+            "format_specifier": {
+                "decimal": 3,
+                "integer": 3
+            },
+            "output_type": "drill",
+            "outputs": [
+                {
+                    "advanced_options": {
+                        "mirror": false,
+                        "offset_x": 0,
+                        "offset_y": 0,
+                        "rotate": false,
+                        "upside_down": false
+                    },
+                    "filename_format": "%DRILLPREFIX/drill_%FROM_%TO.xln",
+                    "name": "Auto Drill",
+                    "type": "autodrills"
+                }
+            ]
+        },
+        {
+            "filename_prefix": "CAMOutputs/Assembly",
+            "output_type": "assembly",
+            "outputs": [
+                {
+                    "filename_format": "%ASSEMBLYPREFIX/%N",
+                    "list_attribute": true,
+                    "list_type": "values",
+                    "name": "Bill of Material",
+                    "output_format": "txt",
+                    "type": "bom"
+                }
+            ]
+        },
+        {
+            "filename_prefix": "CAMOutputs/DrawingFiles",
+            "output_type": "drawing",
+            "outputs": [
+            ]
+        }
+    ],
+    "timestamp": "2019-06-08T20:47:41",
+    "type": "EAGLE CAM job",
+    "units": "metric",
+    "version": "9.2.0"
+}

--- a/PCB/MacroPad.sch
+++ b/PCB/MacroPad.sch
@@ -336,6 +336,45 @@ Note- Available clearance varies from computer to computer. This distance has be
 <smd name="SHIELD@3" x="-5.08" y="3.81" dx="0.3048" dy="0.1524" layer="1"/>
 <smd name="SHIELD@4" x="-6.35" y="3.81" dx="0.3048" dy="0.1524" layer="1"/>
 </package>
+<package name="CRYSTAL-3.2X2.5">
+<smd name="3" x="1.15" y="0.925" dx="1.3" dy="1.05" layer="1"/>
+<smd name="2" x="1.15" y="-0.925" dx="1.3" dy="1.05" layer="1"/>
+<smd name="1" x="-1.15" y="-0.925" dx="1.3" dy="1.05" layer="1"/>
+<smd name="4" x="-1.15" y="0.925" dx="1.3" dy="1.05" layer="1"/>
+<rectangle x1="-1.8" y1="-1.4" x2="1.8" y2="1.4" layer="39"/>
+<wire x1="-1.6" y1="0.15" x2="-1.6" y2="-0.15" width="0.127" layer="47"/>
+<wire x1="1.6" y1="0.15" x2="1.6" y2="-0.15" width="0.127" layer="47"/>
+<wire x1="-0.3" y1="-1.25" x2="0.3" y2="-1.25" width="0.127" layer="47"/>
+<wire x1="-0.3" y1="1.25" x2="0.3" y2="1.25" width="0.127" layer="47"/>
+<wire x1="-1.9" y1="1.55" x2="-1.1" y2="1.55" width="0.127" layer="21"/>
+<wire x1="-1.9" y1="1.55" x2="-1.9" y2="0.4" width="0.127" layer="21"/>
+<wire x1="-1.9" y1="-0.4" x2="-1.9" y2="-1.55" width="0.127" layer="21"/>
+<wire x1="-1.9" y1="-1.55" x2="-1.1" y2="-1.55" width="0.127" layer="21"/>
+<wire x1="1.1" y1="-1.55" x2="1.9" y2="-1.55" width="0.127" layer="21"/>
+<wire x1="1.9" y1="-1.55" x2="1.9" y2="-0.8" width="0.127" layer="21"/>
+<wire x1="1.1" y1="1.55" x2="1.9" y2="1.55" width="0.127" layer="21"/>
+<wire x1="1.9" y1="1.55" x2="1.9" y2="0.8" width="0.127" layer="21"/>
+<text x="0" y="1.65" size="1.27" layer="21" font="vector" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-1.65" size="1.27" layer="21" font="vector" align="top-center">&gt;VALUE</text>
+</package>
+<package name="CRYSTAL-3.2X5">
+<description>3.2 x 5 mm crystal</description>
+<smd name="3" x="2" y="1.2" dx="1.8" dy="1.2" layer="1"/>
+<smd name="2" x="2" y="-1.2" dx="1.8" dy="1.2" layer="1"/>
+<smd name="1" x="-2" y="-1.2" dx="1.8" dy="1.2" layer="1"/>
+<smd name="4" x="-2" y="1.2" dx="1.8" dy="1.2" layer="1"/>
+<rectangle x1="-2.6" y1="-1.7" x2="2.6" y2="1.7" layer="39"/>
+<wire x1="-3.125" y1="2" x2="-1.1" y2="2" width="0.127" layer="21"/>
+<wire x1="-3.125" y1="2" x2="-3.125" y2="0.75" width="0.127" layer="21"/>
+<wire x1="-3.125" y1="-0.75" x2="-3.125" y2="-2" width="0.127" layer="21"/>
+<wire x1="-3.125" y1="-2" x2="-1.1" y2="-2" width="0.127" layer="21"/>
+<wire x1="1.1" y1="-2" x2="3.125" y2="-2" width="0.127" layer="21"/>
+<wire x1="3.125" y1="-2" x2="3.125" y2="-0.75" width="0.127" layer="21"/>
+<wire x1="1.1" y1="2" x2="3.125" y2="2" width="0.127" layer="21"/>
+<wire x1="3.125" y1="2" x2="3.125" y2="0.75" width="0.127" layer="21"/>
+<text x="0" y="2.25" size="1.27" layer="21" font="vector" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-2.25" size="1.27" layer="21" font="vector" align="top-center">&gt;VALUE</text>
+</package>
 </packages>
 <symbols>
 <symbol name="USB">
@@ -370,6 +409,22 @@ Note- Available clearance varies from computer to computer. This distance has be
 <pin name="SHIELD@2" x="2.54" y="-12.7" length="middle" rot="R180"/>
 <pin name="SHIELD@3" x="2.54" y="-15.24" length="middle" rot="R180"/>
 <pin name="SHIELD@4" x="2.54" y="-17.78" length="middle" rot="R180"/>
+</symbol>
+<symbol name="CRYSTAL-4PAD">
+<wire x1="-3.683" y1="1.524" x2="-3.683" y2="-1.524" width="0.254" layer="94"/>
+<wire x1="-3.683" y1="-1.524" x2="-1.397" y2="-1.524" width="0.254" layer="94"/>
+<wire x1="-1.397" y1="-1.524" x2="-1.397" y2="1.524" width="0.254" layer="94"/>
+<wire x1="-1.397" y1="1.524" x2="-3.683" y2="1.524" width="0.254" layer="94"/>
+<wire x1="0" y1="1.778" x2="0" y2="-1.778" width="0.254" layer="94"/>
+<wire x1="-5.08" y1="1.778" x2="-5.08" y2="-1.778" width="0.254" layer="94"/>
+<text x="-2.54" y="2.54" size="1.778" layer="95" font="vector" align="bottom-center">&gt;NAME</text>
+<text x="-2.54" y="5.08" size="1.778" layer="96" font="vector" align="bottom-center">&gt;VALUE</text>
+<text x="-4.699" y="-1.143" size="0.8636" layer="93">1</text>
+<text x="-1.016" y="-1.143" size="0.8636" layer="93">2</text>
+<pin name="2" x="2.54" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="1" x="-7.62" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
+<pin name="GND" x="-2.54" y="-5.08" visible="off" length="short" rot="R90"/>
+<text x="-3.048" y="-2.667" size="0.8636" layer="93" align="top-right">GND</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -428,50 +483,38 @@ Note- Available clearance varies from computer to computer. This distance has be
 </device>
 </devices>
 </deviceset>
+<deviceset name="CRYSTAL-4PIN" prefix="Y" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="CRYSTAL-4PAD" x="0" y="0"/>
+</gates>
+<devices>
+<device name="-3.2X2.5" package="CRYSTAL-3.2X2.5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="3"/>
+<connect gate="G$1" pin="GND" pad="2 4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-3.2X5" package="CRYSTAL-3.2X5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="3"/>
+<connect gate="G$1" pin="GND" pad="2 4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
 </devicesets>
 </library>
 <library name="Components">
 <description>Standard Components used in nearly every electrical design</description>
 <packages>
-<package name="CRYSTAL-3.2X2.5">
-<smd name="3" x="1.15" y="0.925" dx="1.3" dy="1.05" layer="1"/>
-<smd name="2" x="1.15" y="-0.925" dx="1.3" dy="1.05" layer="1"/>
-<smd name="1" x="-1.15" y="-0.925" dx="1.3" dy="1.05" layer="1"/>
-<smd name="4" x="-1.15" y="0.925" dx="1.3" dy="1.05" layer="1"/>
-<rectangle x1="-1.8" y1="-1.4" x2="1.8" y2="1.4" layer="39"/>
-<wire x1="-1.6" y1="0.15" x2="-1.6" y2="-0.15" width="0.127" layer="47"/>
-<wire x1="1.6" y1="0.15" x2="1.6" y2="-0.15" width="0.127" layer="47"/>
-<wire x1="-0.3" y1="-1.25" x2="0.3" y2="-1.25" width="0.127" layer="47"/>
-<wire x1="-0.3" y1="1.25" x2="0.3" y2="1.25" width="0.127" layer="47"/>
-<wire x1="-1.9" y1="1.55" x2="-1.1" y2="1.55" width="0.127" layer="21"/>
-<wire x1="-1.9" y1="1.55" x2="-1.9" y2="0.4" width="0.127" layer="21"/>
-<wire x1="-1.9" y1="-0.4" x2="-1.9" y2="-1.55" width="0.127" layer="21"/>
-<wire x1="-1.9" y1="-1.55" x2="-1.1" y2="-1.55" width="0.127" layer="21"/>
-<wire x1="1.1" y1="-1.55" x2="1.9" y2="-1.55" width="0.127" layer="21"/>
-<wire x1="1.9" y1="-1.55" x2="1.9" y2="-0.8" width="0.127" layer="21"/>
-<wire x1="1.1" y1="1.55" x2="1.9" y2="1.55" width="0.127" layer="21"/>
-<wire x1="1.9" y1="1.55" x2="1.9" y2="0.8" width="0.127" layer="21"/>
-<text x="0" y="1.65" size="1.27" layer="21" font="vector" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1.65" size="1.27" layer="21" font="vector" align="top-center">&gt;VALUE</text>
-</package>
-<package name="CRYSTAL-3.2X5">
-<description>3.2 x 5 mm crystal</description>
-<smd name="3" x="2" y="1.2" dx="1.8" dy="1.2" layer="1"/>
-<smd name="2" x="2" y="-1.2" dx="1.8" dy="1.2" layer="1"/>
-<smd name="1" x="-2" y="-1.2" dx="1.8" dy="1.2" layer="1"/>
-<smd name="4" x="-2" y="1.2" dx="1.8" dy="1.2" layer="1"/>
-<rectangle x1="-2.6" y1="-1.7" x2="2.6" y2="1.7" layer="39"/>
-<wire x1="-3.125" y1="2" x2="-1.1" y2="2" width="0.127" layer="21"/>
-<wire x1="-3.125" y1="2" x2="-3.125" y2="0.75" width="0.127" layer="21"/>
-<wire x1="-3.125" y1="-0.75" x2="-3.125" y2="-2" width="0.127" layer="21"/>
-<wire x1="-3.125" y1="-2" x2="-1.1" y2="-2" width="0.127" layer="21"/>
-<wire x1="1.1" y1="-2" x2="3.125" y2="-2" width="0.127" layer="21"/>
-<wire x1="3.125" y1="-2" x2="3.125" y2="-0.75" width="0.127" layer="21"/>
-<wire x1="1.1" y1="2" x2="3.125" y2="2" width="0.127" layer="21"/>
-<wire x1="3.125" y1="2" x2="3.125" y2="0.75" width="0.127" layer="21"/>
-<text x="0" y="2.25" size="1.27" layer="21" font="vector" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-2.25" size="1.27" layer="21" font="vector" align="top-center">&gt;VALUE</text>
-</package>
 <package name="C0603">
 <wire x1="-0.725" y1="0.35" x2="0.725" y2="0.35" width="0.1016" layer="51"/>
 <wire x1="0.725" y1="-0.35" x2="-0.725" y2="-0.35" width="0.1016" layer="51"/>
@@ -612,22 +655,6 @@ Note- Available clearance varies from computer to computer. This distance has be
 </package>
 </packages>
 <symbols>
-<symbol name="CRYSTAL-4PAD">
-<wire x1="-3.683" y1="1.524" x2="-3.683" y2="-1.524" width="0.254" layer="94"/>
-<wire x1="-3.683" y1="-1.524" x2="-1.397" y2="-1.524" width="0.254" layer="94"/>
-<wire x1="-1.397" y1="-1.524" x2="-1.397" y2="1.524" width="0.254" layer="94"/>
-<wire x1="-1.397" y1="1.524" x2="-3.683" y2="1.524" width="0.254" layer="94"/>
-<wire x1="0" y1="1.778" x2="0" y2="-1.778" width="0.254" layer="94"/>
-<wire x1="-5.08" y1="1.778" x2="-5.08" y2="-1.778" width="0.254" layer="94"/>
-<text x="-2.54" y="2.54" size="1.778" layer="95" font="vector" align="bottom-center">&gt;NAME</text>
-<text x="-2.54" y="5.08" size="1.778" layer="96" font="vector" align="bottom-center">&gt;VALUE</text>
-<text x="-4.699" y="-1.143" size="0.8636" layer="93">1</text>
-<text x="-1.016" y="-1.143" size="0.8636" layer="93">2</text>
-<pin name="2" x="2.54" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="1" x="-7.62" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
-<pin name="GND" x="-2.54" y="-5.08" visible="off" length="short" rot="R90"/>
-<text x="-3.048" y="-2.667" size="0.8636" layer="93" align="top-right">GND</text>
-</symbol>
 <symbol name="CAPACITOR">
 <wire x1="-2.54" y1="0" x2="-0.762" y2="0" width="0.1524" layer="94"/>
 <wire x1="2.54" y1="0" x2="0.762" y2="0" width="0.1524" layer="94"/>
@@ -650,33 +677,6 @@ Note- Available clearance varies from computer to computer. This distance has be
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="CRYSTAL-4PIN" prefix="Y" uservalue="yes">
-<gates>
-<gate name="G$1" symbol="CRYSTAL-4PAD" x="0" y="0"/>
-</gates>
-<devices>
-<device name="-3.2X2.5" package="CRYSTAL-3.2X2.5">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="3"/>
-<connect gate="G$1" pin="GND" pad="2 4"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-3.2X5" package="CRYSTAL-3.2X5">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="3"/>
-<connect gate="G$1" pin="GND" pad="2 4"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
 <deviceset name="CAPACITOR" prefix="C" uservalue="yes">
 <gates>
 <gate name="G$1" symbol="CAPACITOR" x="0" y="0"/>
@@ -11074,11 +11074,6 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="Y1" library="Components" deviceset="CRYSTAL-4PIN" device="-3.2X2.5">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
 <part name="SUPPLY1" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="GND" device=""/>
 <part name="SUPPLY3" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="VCC" device=""/>
 <part name="SUPPLY4" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="VCC" device=""/>
@@ -11237,6 +11232,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <part name="D11" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
 <part name="U1" library="ATMEGA32U4-AUR" deviceset="ATMEGA32U4-AUR" device=""/>
 <part name="SUPPLY9" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="GND" device=""/>
+<part name="Y1" library="Controller" deviceset="CRYSTAL-4PIN" device="-3.2X5"/>
 </parts>
 <sheets>
 <sheet>
@@ -11249,13 +11245,6 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="OC_NEWARK" x="30.48" y="81.28" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="30.48" y="81.28" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="30.48" y="81.28" size="1.778" layer="96" display="off"/>
-</instance>
-<instance part="Y1" gate="G$1" x="104.14" y="33.02" smashed="yes" rot="R270">
-<attribute name="NAME" x="106.68" y="35.56" size="1.778" layer="95" font="vector" rot="R270" align="bottom-center"/>
-<attribute name="VALUE" x="109.22" y="35.56" size="1.778" layer="96" font="vector" rot="R270" align="bottom-center"/>
-<attribute name="OC_NEWARK" x="104.14" y="33.02" size="1.778" layer="96" rot="R270" display="off"/>
-<attribute name="MF" x="104.14" y="33.02" size="1.778" layer="96" rot="R270" display="off"/>
-<attribute name="MPN" x="104.14" y="33.02" size="1.778" layer="96" rot="R270" display="off"/>
 </instance>
 <instance part="SUPPLY1" gate="GND" x="86.36" y="35.56" smashed="yes" rot="R270">
 <attribute name="VALUE" x="83.185" y="37.465" size="1.778" layer="96" rot="R270"/>
@@ -11515,13 +11504,16 @@ In this library the device names are the same as the pin names of the symbols, t
 <instance part="SUPPLY9" gate="GND" x="116.84" y="33.02" smashed="yes">
 <attribute name="VALUE" x="114.935" y="29.845" size="1.778" layer="96"/>
 </instance>
+<instance part="Y1" gate="G$1" x="104.14" y="33.02" smashed="yes" rot="R270">
+<attribute name="NAME" x="106.68" y="35.56" size="1.778" layer="95" font="vector" rot="R270" align="bottom-center"/>
+<attribute name="VALUE" x="109.22" y="35.56" size="1.778" layer="96" font="vector" rot="R270" align="bottom-center"/>
+</instance>
 </instances>
 <busses>
 </busses>
 <nets>
 <net name="N$1" class="0">
 <segment>
-<pinref part="Y1" gate="G$1" pin="2"/>
 <wire x1="104.14" y1="30.48" x2="104.14" y2="27.94" width="0.1524" layer="91"/>
 <junction x="104.14" y="27.94"/>
 <wire x1="101.6" y1="27.94" x2="104.14" y2="27.94" width="0.1524" layer="91"/>
@@ -11530,18 +11522,19 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="170.18" y1="43.18" x2="177.8" y2="43.18" width="0.1524" layer="91"/>
 <wire x1="177.8" y1="43.18" x2="177.8" y2="27.94" width="0.1524" layer="91"/>
 <wire x1="177.8" y1="27.94" x2="104.14" y2="27.94" width="0.1524" layer="91"/>
+<pinref part="Y1" gate="G$1" pin="2"/>
 </segment>
 </net>
 <net name="N$2" class="0">
 <segment>
 <wire x1="104.14" y1="78.74" x2="104.14" y2="43.18" width="0.1524" layer="91"/>
-<pinref part="Y1" gate="G$1" pin="1"/>
 <wire x1="104.14" y1="43.18" x2="101.6" y2="43.18" width="0.1524" layer="91"/>
 <wire x1="104.14" y1="40.64" x2="104.14" y2="43.18" width="0.1524" layer="91"/>
 <junction x="104.14" y="43.18"/>
 <pinref part="C1" gate="G$1" pin="2"/>
 <pinref part="U1" gate="A" pin="XTAL1"/>
 <wire x1="104.14" y1="78.74" x2="134.62" y2="78.74" width="0.1524" layer="91"/>
+<pinref part="Y1" gate="G$1" pin="1"/>
 </segment>
 </net>
 <net name="VCC" class="0">
@@ -11952,10 +11945,10 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="91.44" y1="27.94" x2="88.9" y2="27.94" width="0.1524" layer="91"/>
 <wire x1="88.9" y1="27.94" x2="88.9" y2="35.56" width="0.1524" layer="91"/>
 <junction x="88.9" y="35.56"/>
-<pinref part="Y1" gate="G$1" pin="GND"/>
 <wire x1="99.06" y1="35.56" x2="88.9" y2="35.56" width="0.1524" layer="91"/>
 <pinref part="C1" gate="G$1" pin="1"/>
 <pinref part="C2" gate="G$1" pin="1"/>
+<pinref part="Y1" gate="G$1" pin="GND"/>
 </segment>
 <segment>
 <pinref part="SUPPLY5" gate="GND" pin="GND"/>

--- a/PCB/MacroPad.sch
+++ b/PCB/MacroPad.sch
@@ -11141,7 +11141,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="SW00" library="Hardware" deviceset="SWITCH-SMD" device="-EVQP-P2602W">
+<part name="RESET" library="Hardware" deviceset="SWITCH-SMD" device="-EVQP-P2602W">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -11176,22 +11176,17 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MPN" value="04025A220JAT2A"/>
 <attribute name="OC_NEWARK" value="96M1143"/>
 </part>
-<part name="C8" library="Components" deviceset="CAPACITOR" device="-0603" value="1u">
+<part name="C3" library="Components" deviceset="CAPACITOR" device="-0603" value="1u">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="C4" library="Components" deviceset="CAPACITOR" device="-0603" value="0.1u">
+<part name="C8" library="Components" deviceset="CAPACITOR" device="-0603" value="0.1u">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="C5" library="Components" deviceset="CAPACITOR" device="-0603" value="0.1u">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
-<part name="C6" library="Components" deviceset="CAPACITOR" device="-0603" value="0.1u">
+<part name="C9" library="Components" deviceset="CAPACITOR" device="-0603" value="0.1u">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -11201,7 +11196,12 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="C3" library="Components" deviceset="CAPACITOR" device="-0603" value="4.7u">
+<part name="C6" library="Components" deviceset="CAPACITOR" device="-0603" value="0.1u">
+<attribute name="MF" value=""/>
+<attribute name="MPN" value=""/>
+<attribute name="OC_NEWARK" value="unknown"/>
+</part>
+<part name="C5" library="Components" deviceset="CAPACITOR" device="-0603" value="4.7u">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -11212,7 +11212,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
 <part name="SUPPLY10" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="GND" device=""/>
-<part name="C9" library="Components" deviceset="CAPACITOR" device="-0603" value="0.1u">
+<part name="C4" library="Components" deviceset="CAPACITOR" device="-0603" value="0.1u">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -11339,7 +11339,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MF" x="276.86" y="25.4" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="276.86" y="25.4" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW00" gate="G$1" x="91.44" y="106.68" smashed="yes">
+<instance part="RESET" gate="G$1" x="91.44" y="106.68" smashed="yes">
 <attribute name="NAME" x="91.44" y="104.394" size="1.27" layer="95" align="bottom-center"/>
 <attribute name="OC_NEWARK" x="91.44" y="106.68" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="91.44" y="106.68" size="1.778" layer="96" display="off"/>
@@ -11387,47 +11387,47 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MF" x="96.52" y="27.94" size="1.778" layer="96" rot="R270" display="off"/>
 <attribute name="MPN" x="96.52" y="27.94" size="1.778" layer="96" rot="R270" display="off"/>
 </instance>
-<instance part="C8" gate="G$1" x="88.9" y="86.36" smashed="yes" rot="R180">
+<instance part="C3" gate="G$1" x="88.9" y="86.36" smashed="yes" rot="R180">
 <attribute name="NAME" x="93.98" y="85.852" size="1.778" layer="95" rot="R180"/>
 <attribute name="VALUE" x="87.884" y="86.614" size="1.778" layer="96" rot="R180" align="top-left"/>
 <attribute name="OC_NEWARK" x="88.9" y="86.36" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="88.9" y="86.36" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="88.9" y="86.36" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="C4" gate="G$1" x="20.32" y="40.64" smashed="yes" rot="R270">
-<attribute name="NAME" x="20.828" y="45.72" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="20.066" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="20.32" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="20.32" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="20.32" y="40.64" size="1.778" layer="96" display="off"/>
-</instance>
-<instance part="C5" gate="G$1" x="27.94" y="40.64" smashed="yes" rot="R270">
-<attribute name="NAME" x="28.448" y="45.72" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="27.686" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="27.94" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="27.94" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="27.94" y="40.64" size="1.778" layer="96" display="off"/>
-</instance>
-<instance part="C6" gate="G$1" x="35.56" y="40.64" smashed="yes" rot="R270">
-<attribute name="NAME" x="36.068" y="45.72" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="35.306" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="35.56" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="35.56" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="35.56" y="40.64" size="1.778" layer="96" display="off"/>
-</instance>
-<instance part="C7" gate="G$1" x="43.18" y="40.64" smashed="yes" rot="R270">
+<instance part="C8" gate="G$1" x="43.18" y="40.64" smashed="yes" rot="R270">
 <attribute name="NAME" x="43.688" y="45.72" size="1.778" layer="95" rot="R270"/>
 <attribute name="VALUE" x="42.926" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
 <attribute name="OC_NEWARK" x="43.18" y="40.64" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="43.18" y="40.64" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="43.18" y="40.64" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="C3" gate="G$1" x="12.7" y="40.64" smashed="yes" rot="R270">
-<attribute name="NAME" x="13.208" y="45.72" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="12.446" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
+<instance part="C9" gate="G$1" x="50.8" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="51.308" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="50.546" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
+<attribute name="OC_NEWARK" x="50.8" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="50.8" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="50.8" y="40.64" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="C7" gate="G$1" x="35.56" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="36.068" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="35.306" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
+<attribute name="OC_NEWARK" x="35.56" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="35.56" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="35.56" y="40.64" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="C6" gate="G$1" x="27.94" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="28.448" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="27.686" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
+<attribute name="OC_NEWARK" x="27.94" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="27.94" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="27.94" y="40.64" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="C5" gate="G$1" x="20.32" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="20.828" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="20.066" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
+<attribute name="OC_NEWARK" x="20.32" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="20.32" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="20.32" y="40.64" size="1.778" layer="96" display="off"/>
 </instance>
 <instance part="F1" gate="G$1" x="12.7" y="81.28" smashed="yes" rot="R90">
 <attribute name="NAME" x="15.24" y="71.12" size="1.778" layer="95" rot="R90"/>
@@ -11439,12 +11439,12 @@ In this library the device names are the same as the pin names of the symbols, t
 <instance part="SUPPLY10" gate="GND" x="12.7" y="63.5" smashed="yes">
 <attribute name="VALUE" x="10.795" y="60.325" size="1.778" layer="96"/>
 </instance>
-<instance part="C9" gate="G$1" x="50.8" y="40.64" smashed="yes" rot="R270">
-<attribute name="NAME" x="51.308" y="45.72" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="50.546" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="50.8" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="50.8" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="50.8" y="40.64" size="1.778" layer="96" display="off"/>
+<instance part="C4" gate="G$1" x="12.7" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="13.208" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="12.446" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
+<attribute name="OC_NEWARK" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
 </instance>
 <instance part="SUPPLY2" gate="GND" x="12.7" y="30.48" smashed="yes">
 <attribute name="VALUE" x="10.795" y="27.305" size="1.778" layer="96"/>
@@ -11539,24 +11539,24 @@ In this library the device names are the same as the pin names of the symbols, t
 </net>
 <net name="VCC" class="0">
 <segment>
-<wire x1="43.18" y1="45.72" x2="35.56" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="45.72" x2="35.56" y2="45.72" width="0.1524" layer="91"/>
 <pinref part="SUPPLY3" gate="G$1" pin="VCC"/>
-<wire x1="35.56" y1="45.72" x2="27.94" y2="45.72" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="45.72" x2="20.32" y2="45.72" width="0.1524" layer="91"/>
-<wire x1="20.32" y1="45.72" x2="12.7" y2="45.72" width="0.1524" layer="91"/>
-<wire x1="12.7" y1="48.26" x2="12.7" y2="45.72" width="0.1524" layer="91"/>
-<pinref part="C3" gate="G$1" pin="1"/>
-<junction x="12.7" y="45.72"/>
-<pinref part="C4" gate="G$1" pin="1"/>
-<junction x="20.32" y="45.72"/>
-<pinref part="C5" gate="G$1" pin="1"/>
-<junction x="27.94" y="45.72"/>
-<pinref part="C6" gate="G$1" pin="1"/>
-<junction x="35.56" y="45.72"/>
-<pinref part="C7" gate="G$1" pin="1"/>
-<pinref part="C9" gate="G$1" pin="1"/>
+<wire x1="35.56" y1="45.72" x2="50.8" y2="45.72" width="0.1524" layer="91"/>
 <wire x1="50.8" y1="45.72" x2="43.18" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="45.72" x2="20.32" y2="45.72" width="0.1524" layer="91"/>
+<pinref part="C5" gate="G$1" pin="1"/>
+<pinref part="C8" gate="G$1" pin="1"/>
 <junction x="43.18" y="45.72"/>
+<pinref part="C9" gate="G$1" pin="1"/>
+<junction x="50.8" y="45.72"/>
+<pinref part="C7" gate="G$1" pin="1"/>
+<junction x="35.56" y="45.72"/>
+<pinref part="C6" gate="G$1" pin="1"/>
+<pinref part="C4" gate="G$1" pin="1"/>
+<wire x1="12.7" y1="45.72" x2="27.94" y2="45.72" width="0.1524" layer="91"/>
+<junction x="27.94" y="45.72"/>
+<wire x1="12.7" y1="45.72" x2="12.7" y2="48.26" width="0.1524" layer="91"/>
+<junction x="12.7" y="45.72"/>
 </segment>
 <segment>
 <pinref part="SUPPLY4" gate="G$1" pin="VCC"/>
@@ -11598,7 +11598,7 @@ In this library the device names are the same as the pin names of the symbols, t
 </net>
 <net name="N$3" class="0">
 <segment>
-<pinref part="SW00" gate="G$1" pin="2"/>
+<pinref part="RESET" gate="G$1" pin="2"/>
 <wire x1="96.52" y1="106.68" x2="99.06" y2="106.68" width="0.1524" layer="91"/>
 <pinref part="U1" gate="A" pin="~RESET"/>
 <wire x1="99.06" y1="106.68" x2="104.14" y2="106.68" width="0.1524" layer="91"/>
@@ -11612,7 +11612,7 @@ In this library the device names are the same as the pin names of the symbols, t
 </net>
 <net name="UCAP" class="0">
 <segment>
-<pinref part="C8" gate="G$1" pin="1"/>
+<pinref part="C3" gate="G$1" pin="1"/>
 <pinref part="U1" gate="A" pin="UCAP"/>
 <wire x1="96.52" y1="76.2" x2="134.62" y2="76.2" width="0.1524" layer="91"/>
 <wire x1="93.98" y1="86.36" x2="96.52" y2="86.36" width="0.1524" layer="91"/>
@@ -11910,24 +11910,24 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="12.7" y1="66.04" x2="12.7" y2="68.58" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<pinref part="C7" gate="G$1" pin="2"/>
-<pinref part="C9" gate="G$1" pin="2"/>
-<wire x1="50.8" y1="35.56" x2="43.18" y2="35.56" width="0.1524" layer="91"/>
-<junction x="43.18" y="35.56"/>
-<wire x1="43.18" y1="35.56" x2="35.56" y2="35.56" width="0.1524" layer="91"/>
 <pinref part="C6" gate="G$1" pin="2"/>
-<junction x="35.56" y="35.56"/>
-<wire x1="35.56" y1="35.56" x2="27.94" y2="35.56" width="0.1524" layer="91"/>
-<pinref part="C5" gate="G$1" pin="2"/>
-<junction x="27.94" y="35.56"/>
-<wire x1="27.94" y1="35.56" x2="20.32" y2="35.56" width="0.1524" layer="91"/>
 <pinref part="C4" gate="G$1" pin="2"/>
-<junction x="20.32" y="35.56"/>
-<wire x1="20.32" y1="35.56" x2="12.7" y2="35.56" width="0.1524" layer="91"/>
-<pinref part="C3" gate="G$1" pin="2"/>
-<junction x="12.7" y="35.56"/>
-<wire x1="12.7" y1="33.02" x2="12.7" y2="35.56" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="35.56" x2="27.94" y2="35.56" width="0.1524" layer="91"/>
+<junction x="27.94" y="35.56"/>
+<wire x1="27.94" y1="35.56" x2="35.56" y2="35.56" width="0.1524" layer="91"/>
+<pinref part="C7" gate="G$1" pin="2"/>
+<junction x="35.56" y="35.56"/>
+<wire x1="35.56" y1="35.56" x2="50.8" y2="35.56" width="0.1524" layer="91"/>
+<pinref part="C9" gate="G$1" pin="2"/>
+<junction x="50.8" y="35.56"/>
+<wire x1="50.8" y1="35.56" x2="43.18" y2="35.56" width="0.1524" layer="91"/>
+<pinref part="C8" gate="G$1" pin="2"/>
+<junction x="43.18" y="35.56"/>
+<wire x1="43.18" y1="35.56" x2="20.32" y2="35.56" width="0.1524" layer="91"/>
+<pinref part="C5" gate="G$1" pin="2"/>
 <pinref part="SUPPLY2" gate="GND" pin="GND"/>
+<wire x1="12.7" y1="35.56" x2="12.7" y2="33.02" width="0.1524" layer="91"/>
+<junction x="12.7" y="35.56"/>
 </segment>
 <segment>
 <pinref part="USB1" gate="G$1" pin="GND"/>
@@ -11936,7 +11936,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <junction x="55.88" y="86.36"/>
 <wire x1="55.88" y1="86.36" x2="55.88" y2="81.28" width="0.1524" layer="91"/>
 <pinref part="SUPPLY7" gate="GND" pin="GND"/>
-<pinref part="C8" gate="G$1" pin="2"/>
+<pinref part="C3" gate="G$1" pin="2"/>
 </segment>
 <segment>
 <wire x1="91.44" y1="43.18" x2="88.9" y2="43.18" width="0.1524" layer="91"/>
@@ -11953,7 +11953,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <segment>
 <pinref part="SUPPLY5" gate="GND" pin="GND"/>
 <wire x1="83.82" y1="106.68" x2="86.36" y2="106.68" width="0.1524" layer="91"/>
-<pinref part="SW00" gate="G$1" pin="1"/>
+<pinref part="RESET" gate="G$1" pin="1"/>
 </segment>
 <segment>
 <pinref part="SUPPLY6" gate="GND" pin="GND"/>

--- a/PCB/MacroPad.sch
+++ b/PCB/MacroPad.sch
@@ -777,202 +777,6 @@ Note- Available clearance varies from computer to computer. This distance has be
 <wire x1="-2.625" y1="-1.25" x2="2.625" y2="-1.25" width="0.25" layer="22"/>
 <wire x1="2.625" y1="1.25" x2="2.625" y2="-1.25" width="0.25" layer="22"/>
 </package>
-<package name="SOD-323">
-<description>SOD-123 footprint</description>
-<wire x1="-1.325" y1="-1" x2="-1.325" y2="1" width="0.127" layer="51"/>
-<wire x1="1.325" y1="1" x2="1.325" y2="-1" width="0.127" layer="51"/>
-<wire x1="-1.325" y1="1.5" x2="1.325" y2="1.5" width="0.127" layer="21"/>
-<wire x1="1.325" y1="-1.5" x2="-1.325" y2="-1.5" width="0.127" layer="21"/>
-<wire x1="0.381" y1="0" x2="-0.381" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.635" x2="-0.381" y2="-0.508" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.508" x2="-0.381" y2="-0.381" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.381" x2="-0.381" y2="0.635" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="0.635" x2="0.381" y2="0" width="0.127" layer="21"/>
-<wire x1="0.381" y1="0" x2="-0.381" y2="-0.508" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.508" x2="-0.254" y2="0.508" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.508" x2="0.254" y2="0" width="0.127" layer="21"/>
-<wire x1="0.254" y1="0" x2="-0.381" y2="-0.381" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.381" x2="-0.254" y2="0.381" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.381" x2="0.127" y2="0" width="0.127" layer="21"/>
-<wire x1="0.127" y1="0" x2="-0.254" y2="-0.254" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.254" x2="-0.254" y2="-0.127" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.127" x2="-0.254" y2="0.254" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.254" x2="-0.127" y2="0.127" width="0.127" layer="21"/>
-<wire x1="-0.127" y1="0.127" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="-0.254" y2="-0.127" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.127" x2="-0.127" y2="0.127" width="0.127" layer="21"/>
-<wire x1="-0.127" y1="0.127" x2="-0.127" y2="0" width="0.127" layer="21"/>
-<smd name="C" x="1.55" y="0" dx="0.9" dy="0.95" layer="1" rot="R270"/>
-<smd name="A" x="-1.55" y="0" dx="0.9" dy="0.95" layer="1" rot="R270"/>
-<rectangle x1="1.2" y1="-0.4" x2="1.95" y2="0.45" layer="51" rot="R180"/>
-<rectangle x1="-1.95" y1="-0.4" x2="-1.2" y2="0.45" layer="51" rot="R180"/>
-<text x="0" y="1.77" size="1" layer="21" font="vector" ratio="13" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1.77" size="1" layer="21" font="vector" ratio="13" align="top-center">&gt;VALUE</text>
-<text x="2.25" y="0" size="0.75" layer="21" align="center-left">K</text>
-</package>
-<package name="DO-35">
-<pad name="A" x="4.82" y="0" drill="1" diameter="2" shape="square"/>
-<pad name="C" x="-4.82" y="0" drill="1" diameter="2"/>
-<wire x1="-3.683" y1="-1.27" x2="-3.683" y2="1.27" width="0.2" layer="21"/>
-<wire x1="3.683" y1="1.27" x2="3.683" y2="-1.27" width="0.2" layer="21"/>
-<wire x1="-3.683" y1="1.27" x2="3.683" y2="1.27" width="0.2" layer="21"/>
-<wire x1="3.683" y1="-1.27" x2="-3.683" y2="-1.27" width="0.2" layer="21"/>
-<wire x1="0.381" y1="0" x2="-0.381" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.635" x2="-0.381" y2="-0.508" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.508" x2="-0.381" y2="-0.381" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.381" x2="-0.381" y2="0.635" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="0.635" x2="0.381" y2="0" width="0.127" layer="21"/>
-<wire x1="0.381" y1="0" x2="-0.381" y2="-0.508" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.508" x2="-0.254" y2="0.508" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.508" x2="0.254" y2="0" width="0.127" layer="21"/>
-<wire x1="0.254" y1="0" x2="-0.381" y2="-0.381" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.381" x2="-0.254" y2="0.381" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.381" x2="0.127" y2="0" width="0.127" layer="21"/>
-<wire x1="0.127" y1="0" x2="-0.254" y2="-0.254" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.254" x2="-0.254" y2="-0.127" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.127" x2="-0.254" y2="0.254" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.254" x2="-0.127" y2="0.127" width="0.127" layer="21"/>
-<wire x1="-0.127" y1="0.127" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="-0.254" y2="-0.127" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.127" x2="-0.127" y2="0.127" width="0.127" layer="21"/>
-<wire x1="-0.127" y1="0.127" x2="-0.127" y2="0" width="0.127" layer="21"/>
-<text x="0" y="1.905" size="1.5" layer="21" font="vector" ratio="13" align="bottom-center">&gt;NAME</text>
-<wire x1="3" y1="1.25" x2="3" y2="-1.25" width="0.2" layer="21"/>
-</package>
-<package name="DIODE_HAND">
-<pad name="C2" x="3.5" y="0" drill="1" diameter="1.9" shape="square"/>
-<pad name="A2" x="-3.5" y="0" drill="1" diameter="1.9"/>
-<wire x1="0.381" y1="0" x2="-0.381" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.635" x2="-0.381" y2="-0.508" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.508" x2="-0.381" y2="-0.381" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.381" x2="-0.381" y2="0.635" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="0.635" x2="0.381" y2="0" width="0.127" layer="21"/>
-<wire x1="0.381" y1="0" x2="-0.381" y2="-0.508" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.508" x2="-0.254" y2="0.508" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.508" x2="0.254" y2="0" width="0.127" layer="21"/>
-<wire x1="0.254" y1="0" x2="-0.381" y2="-0.381" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.381" x2="-0.254" y2="0.381" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.381" x2="0.127" y2="0" width="0.127" layer="21"/>
-<wire x1="0.127" y1="0" x2="-0.254" y2="-0.254" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.254" x2="-0.254" y2="-0.127" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.127" x2="-0.254" y2="0.254" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.254" x2="-0.127" y2="0.127" width="0.127" layer="21"/>
-<wire x1="-0.127" y1="0.127" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="-0.254" y2="-0.127" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.127" x2="-0.127" y2="0.127" width="0.127" layer="21"/>
-<wire x1="-0.127" y1="0.127" x2="-0.127" y2="0" width="0.127" layer="21"/>
-<text x="0" y="1.905" size="1.27" layer="21" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1.905" size="1.27" layer="21" font="vector" align="top-center">&gt;VALUE</text>
-<smd name="C1" x="1.651" y="0" dx="1.397" dy="1.397" layer="1" rot="R180"/>
-<smd name="A1" x="-1.651" y="0" dx="1.397" dy="1.397" layer="1" rot="R180"/>
-<smd name="A3" x="-1.651" y="0" dx="1.397" dy="1.397" layer="16"/>
-<smd name="C3" x="1.651" y="0" dx="1.397" dy="1.397" layer="16"/>
-<wire x1="2.6" y1="0.8" x2="2.6" y2="-0.8" width="0.127" layer="21"/>
-<wire x1="2.6" y1="0.8" x2="2.6" y2="-0.8" width="0.127" layer="22"/>
-<wire x1="2.6" y1="1.2" x2="2.6" y2="-1.2" width="0.25" layer="22"/>
-<wire x1="2.6" y1="1.2" x2="2.6" y2="-1.2" width="0.25" layer="21"/>
-<wire x1="2.5" y1="1" x2="-2.5" y2="1" width="0.25" layer="21"/>
-<wire x1="-2.5" y1="1" x2="-2.5" y2="-1" width="0.25" layer="21"/>
-<wire x1="-2.5" y1="-1" x2="2.5" y2="-1" width="0.25" layer="21"/>
-<wire x1="-2.5" y1="1" x2="2.5" y2="1" width="0.25" layer="22"/>
-<wire x1="2.5" y1="-1" x2="-2.5" y2="-1" width="0.25" layer="22"/>
-<wire x1="-2.5" y1="1" x2="-2.5" y2="-1" width="0.25" layer="22"/>
-<wire x1="0.381" y1="0" x2="-0.381" y2="0.635" width="0.127" layer="22"/>
-<wire x1="-0.381" y1="0.635" x2="-0.381" y2="0.508" width="0.127" layer="22"/>
-<wire x1="-0.381" y1="0.508" x2="-0.381" y2="0.381" width="0.127" layer="22"/>
-<wire x1="-0.381" y1="0.381" x2="-0.381" y2="-0.635" width="0.127" layer="22"/>
-<wire x1="-0.381" y1="-0.635" x2="0.381" y2="0" width="0.127" layer="22"/>
-<wire x1="0.381" y1="0" x2="-0.381" y2="0.508" width="0.127" layer="22"/>
-<wire x1="-0.381" y1="0.508" x2="-0.254" y2="-0.508" width="0.127" layer="22"/>
-<wire x1="-0.254" y1="-0.508" x2="0.254" y2="0" width="0.127" layer="22"/>
-<wire x1="0.254" y1="0" x2="-0.381" y2="0.381" width="0.127" layer="22"/>
-<wire x1="-0.381" y1="0.381" x2="-0.254" y2="-0.381" width="0.127" layer="22"/>
-<wire x1="-0.254" y1="-0.381" x2="0.127" y2="0" width="0.127" layer="22"/>
-<wire x1="0.127" y1="0" x2="-0.254" y2="0.254" width="0.127" layer="22"/>
-<wire x1="-0.254" y1="0.254" x2="-0.254" y2="0.127" width="0.127" layer="22"/>
-<wire x1="-0.254" y1="0.127" x2="-0.254" y2="-0.254" width="0.127" layer="22"/>
-<wire x1="-0.254" y1="-0.254" x2="-0.127" y2="-0.127" width="0.127" layer="22"/>
-<wire x1="-0.127" y1="-0.127" x2="0" y2="0" width="0.127" layer="22"/>
-<wire x1="0" y1="0" x2="-0.254" y2="0.127" width="0.127" layer="22"/>
-<wire x1="-0.254" y1="0.127" x2="-0.127" y2="-0.127" width="0.127" layer="22"/>
-<wire x1="-0.127" y1="-0.127" x2="-0.127" y2="0" width="0.127" layer="22"/>
-</package>
-<package name="SOD-123FL">
-<description>SOD-123 footprint</description>
-<wire x1="1.35" y1="-0.875" x2="-1.35" y2="-0.875" width="0.127" layer="21"/>
-<wire x1="-1.35" y1="0.875" x2="1.35" y2="0.875" width="0.127" layer="21"/>
-<wire x1="0.284" y1="0" x2="1.046" y2="0.635" width="0.127" layer="21"/>
-<wire x1="1.046" y1="0.635" x2="1.046" y2="0.508" width="0.127" layer="21"/>
-<wire x1="1.046" y1="0.508" x2="1.046" y2="0.381" width="0.127" layer="21"/>
-<wire x1="1.046" y1="0.381" x2="1.046" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="1.046" y1="-0.635" x2="0.284" y2="0" width="0.127" layer="21"/>
-<wire x1="0.284" y1="0" x2="1.046" y2="0.508" width="0.127" layer="21"/>
-<wire x1="1.046" y1="0.508" x2="0.919" y2="-0.508" width="0.127" layer="21"/>
-<wire x1="0.919" y1="-0.508" x2="0.411" y2="0" width="0.127" layer="21"/>
-<wire x1="0.411" y1="0" x2="1.046" y2="0.381" width="0.127" layer="21"/>
-<wire x1="1.046" y1="0.381" x2="0.919" y2="-0.381" width="0.127" layer="21"/>
-<wire x1="0.919" y1="-0.381" x2="0.538" y2="0" width="0.127" layer="21"/>
-<wire x1="0.538" y1="0" x2="0.919" y2="0.254" width="0.127" layer="21"/>
-<wire x1="0.919" y1="0.254" x2="0.919" y2="0.127" width="0.127" layer="21"/>
-<wire x1="0.919" y1="0.127" x2="0.919" y2="-0.254" width="0.127" layer="21"/>
-<wire x1="0.919" y1="-0.254" x2="0.792" y2="-0.127" width="0.127" layer="21"/>
-<wire x1="0.792" y1="-0.127" x2="0.665" y2="0" width="0.127" layer="21"/>
-<wire x1="0.665" y1="0" x2="0.919" y2="0.127" width="0.127" layer="21"/>
-<wire x1="0.919" y1="0.127" x2="0.792" y2="-0.127" width="0.127" layer="21"/>
-<wire x1="0.792" y1="-0.127" x2="0.792" y2="0" width="0.127" layer="21"/>
-<smd name="C@1" x="-1.67" y="0" dx="0.85" dy="0.85" layer="1"/>
-<smd name="A" x="1.67" y="0" dx="0.85" dy="0.85" layer="1"/>
-<text x="0" y="1" size="1" layer="21" font="vector" rot="R180" align="top-center">&gt;NAME</text>
-<text x="0" y="-1" size="1" layer="21" font="vector" rot="R180" align="bottom-center">&gt;VALUE</text>
-<smd name="C@2" x="-0.585" y="0" dx="1.32" dy="1.12" layer="1" rot="R180"/>
-</package>
-<package name="DFN0603-2">
-<description>DFN0603-2</description>
-<wire x1="0.305" y1="-0.25" x2="-0.305" y2="-0.25" width="0.1" layer="21"/>
-<wire x1="-0.305" y1="0.25" x2="0.305" y2="0.25" width="0.1" layer="21"/>
-<smd name="C" x="-0.19" y="0" dx="0.23" dy="0.3" layer="1"/>
-<smd name="A" x="0.19" y="0" dx="0.23" dy="0.3" layer="1"/>
-<text x="0" y="0.5" size="1" layer="21" font="vector" ratio="13" rot="R180" align="top-center">&gt;NAME</text>
-<text x="-0.635" y="0" size="0.75" layer="21" font="vector" ratio="13" align="center-right">K</text>
-</package>
-<package name="CST-2">
-<description>DFN0603-2</description>
-<wire x1="0.5" y1="-0.35" x2="-0.5" y2="-0.35" width="0.1" layer="21"/>
-<wire x1="-0.5" y1="0.35" x2="0.5" y2="0.35" width="0.1" layer="21"/>
-<smd name="C" x="-0.325" y="0" dx="0.3" dy="0.55" layer="1"/>
-<smd name="A" x="0.325" y="0" dx="0.3" dy="0.55" layer="1"/>
-<text x="0" y="0.5" size="1" layer="21" font="vector" ratio="13" rot="R180" align="top-center">&gt;NAME</text>
-<text x="-0.635" y="0" size="0.75" layer="21" font="vector" ratio="13" align="center-right">K</text>
-</package>
-<package name="SOD-123">
-<description>SOD-123 footprint</description>
-<wire x1="-1.4" y1="0.8" x2="1.4" y2="0.8" width="0.127" layer="21"/>
-<wire x1="1.4" y1="-0.8" x2="-1.4" y2="-0.8" width="0.127" layer="21"/>
-<wire x1="0.381" y1="0" x2="-0.381" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.635" x2="-0.381" y2="-0.508" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.508" x2="-0.381" y2="-0.381" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.381" x2="-0.381" y2="0.635" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="0.635" x2="0.381" y2="0" width="0.127" layer="21"/>
-<wire x1="0.381" y1="0" x2="-0.381" y2="-0.508" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.508" x2="-0.254" y2="0.508" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.508" x2="0.254" y2="0" width="0.127" layer="21"/>
-<wire x1="0.254" y1="0" x2="-0.381" y2="-0.381" width="0.127" layer="21"/>
-<wire x1="-0.381" y1="-0.381" x2="-0.254" y2="0.381" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.381" x2="0.127" y2="0" width="0.127" layer="21"/>
-<wire x1="0.127" y1="0" x2="-0.254" y2="-0.254" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.254" x2="-0.254" y2="-0.127" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.127" x2="-0.254" y2="0.254" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="0.254" x2="-0.127" y2="0.127" width="0.127" layer="21"/>
-<wire x1="-0.127" y1="0.127" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="-0.254" y2="-0.127" width="0.127" layer="21"/>
-<wire x1="-0.254" y1="-0.127" x2="-0.127" y2="0.127" width="0.127" layer="21"/>
-<wire x1="-0.127" y1="0.127" x2="-0.127" y2="0" width="0.127" layer="21"/>
-<smd name="C" x="1.635" y="0" dx="0.91" dy="1.22" layer="1"/>
-<smd name="A" x="-1.635" y="0" dx="0.91" dy="1.22" layer="1"/>
-<text x="0" y="1" size="1" layer="21" font="vector" ratio="13" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1" size="1" layer="21" font="vector" ratio="13" align="top-center">&gt;VALUE</text>
-<text x="2.5" y="0" size="0.75" layer="21" align="center-left">K</text>
-</package>
 </packages>
 <symbols>
 <symbol name="CRYSTAL-4PAD">
@@ -1010,19 +814,6 @@ Note- Available clearance varies from computer to computer. This distance has be
 <text x="-3.81" y="-3.302" size="1.778" layer="96">&gt;VALUE</text>
 <pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
 <pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
-</symbol>
-<symbol name="DIODE">
-<wire x1="-1.27" y1="-1.905" x2="1.27" y2="0" width="0.254" layer="94"/>
-<wire x1="1.27" y1="0" x2="-1.27" y2="1.905" width="0.254" layer="94"/>
-<wire x1="-1.27" y1="1.905" x2="-1.27" y2="0" width="0.254" layer="94"/>
-<wire x1="-1.27" y1="0" x2="-1.27" y2="-1.905" width="0.254" layer="94"/>
-<wire x1="1.397" y1="1.905" x2="1.397" y2="-1.905" width="0.254" layer="94"/>
-<text x="-2.3114" y="2.6416" size="1.778" layer="95">&gt;NAME</text>
-<text x="-2.5654" y="-4.4958" size="1.778" layer="96">&gt;VALUE</text>
-<pin name="A" x="-5.08" y="0" visible="off" length="short" direction="pas"/>
-<pin name="C" x="5.08" y="0" visible="off" length="short" direction="pas" rot="R180"/>
-<wire x1="-2.54" y1="0" x2="-1.27" y2="0" width="0.1524" layer="94"/>
-<wire x1="1.27" y1="0" x2="2.54" y2="0" width="0.1524" layer="94"/>
 </symbol>
 </symbols>
 <devicesets>
@@ -1150,79 +941,6 @@ Note- Available clearance varies from computer to computer. This distance has be
 <connects>
 <connect gate="G$1" pin="1" pad="A1 A2 A3"/>
 <connect gate="G$1" pin="2" pad="B1 B2 B3"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="DIODE" prefix="D" uservalue="yes">
-<description>Standard 1N4148 diode</description>
-<gates>
-<gate name="D$1" symbol="DIODE" x="0" y="0"/>
-</gates>
-<devices>
-<device name="-SOD-323" package="SOD-323">
-<connects>
-<connect gate="D$1" pin="A" pad="A"/>
-<connect gate="D$1" pin="C" pad="C"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-DO-35" package="DO-35">
-<connects>
-<connect gate="D$1" pin="A" pad="A"/>
-<connect gate="D$1" pin="C" pad="C"/>
-</connects>
-<technologies>
-<technology name="">
-<attribute name="VALUE" value="1N4148" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-HAND" package="DIODE_HAND">
-<connects>
-<connect gate="D$1" pin="A" pad="A1 A2 A3"/>
-<connect gate="D$1" pin="C" pad="C1 C2 C3"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-SOD-123FL" package="SOD-123FL">
-<connects>
-<connect gate="D$1" pin="A" pad="A"/>
-<connect gate="D$1" pin="C" pad="C@1 C@2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-DFN0603-2" package="DFN0603-2">
-<connects>
-<connect gate="D$1" pin="A" pad="A"/>
-<connect gate="D$1" pin="C" pad="C"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-CST-2" package="CST-2">
-<connects>
-<connect gate="D$1" pin="A" pad="A"/>
-<connect gate="D$1" pin="C" pad="C"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-SOD-123" package="SOD-123">
-<connects>
-<connect gate="D$1" pin="A" pad="A"/>
-<connect gate="D$1" pin="C" pad="C"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -10793,6 +10511,358 @@ In this library the device names are the same as the pin names of the symbols, t
 </deviceset>
 </devicesets>
 </library>
+<library name="adafruit" urn="urn:adsk.eagle:library:420">
+<packages>
+<package name="SMADIODE" urn="urn:adsk.eagle:footprint:6240101/1" library_version="2">
+<description>&lt;b&gt;SMA Surface Mount Diode&lt;/b&gt;</description>
+<wire x1="-2.15" y1="1.3" x2="2.15" y2="1.3" width="0.2032" layer="51"/>
+<wire x1="2.15" y1="1.3" x2="2.15" y2="-1.3" width="0.2032" layer="51"/>
+<wire x1="2.15" y1="-1.3" x2="-2.15" y2="-1.3" width="0.2032" layer="51"/>
+<wire x1="-2.15" y1="-1.3" x2="-2.15" y2="1.3" width="0.2032" layer="51"/>
+<wire x1="-3.789" y1="-1.394" x2="-3.789" y2="-1.146" width="0.127" layer="21"/>
+<wire x1="-3.789" y1="-1.146" x2="-3.789" y2="1.6" width="0.127" layer="21"/>
+<wire x1="-3.789" y1="1.6" x2="3.816" y2="1.6" width="0.127" layer="21"/>
+<wire x1="3.816" y1="1.6" x2="3.816" y2="1.394" width="0.127" layer="21"/>
+<wire x1="3.816" y1="1.394" x2="3.816" y2="1.3365" width="0.127" layer="21"/>
+<wire x1="3.816" y1="1.394" x2="3.816" y2="-1.6" width="0.127" layer="21"/>
+<wire x1="3.816" y1="-1.6" x2="-3.789" y2="-1.6" width="0.127" layer="21"/>
+<wire x1="-3.789" y1="-1.6" x2="-3.789" y2="-1.146" width="0.127" layer="21"/>
+<wire x1="-0.3175" y1="-0.4445" x2="-0.3175" y2="0.4445" width="0.127" layer="21"/>
+<wire x1="-0.3175" y1="0.4445" x2="-0.6985" y2="0" width="0.127" layer="21"/>
+<wire x1="-0.6985" y1="0" x2="-0.3175" y2="-0.4445" width="0.127" layer="21"/>
+<wire x1="-0.6985" y1="-0.4445" x2="-0.6985" y2="0.4445" width="0.127" layer="21"/>
+<smd name="C" x="-2.3495" y="0" dx="2.54" dy="2.54" layer="1"/>
+<smd name="A" x="2.3495" y="0" dx="2.54" dy="2.54" layer="1" rot="R180"/>
+<text x="-2.54" y="1.905" size="0.4064" layer="25" font="vector">&gt;NAME</text>
+<text x="-2.54" y="-2.286" size="0.4064" layer="27" font="vector">&gt;VALUE</text>
+<rectangle x1="-2.825" y1="-1.1" x2="-2.175" y2="1.1" layer="51"/>
+<rectangle x1="2.175" y1="-1.1" x2="2.825" y2="1.1" layer="51" rot="R180"/>
+<rectangle x1="-1.75" y1="-1.225" x2="-1.075" y2="1.225" layer="51"/>
+</package>
+<package name="DO-1N4148" urn="urn:adsk.eagle:footprint:6240102/1" library_version="2">
+<wire x1="-2.54" y1="0.762" x2="2.54" y2="0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0.762" x2="2.54" y2="0" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0" x2="2.54" y2="-0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="-0.762" x2="-2.54" y2="-0.762" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="-0.762" x2="-2.54" y2="0" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-2.54" y2="0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0" x2="2.794" y2="0" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-2.794" y2="0" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="0.635" x2="1.905" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="A" x="-3.81" y="0" drill="0.9"/>
+<pad name="C" x="3.81" y="0" drill="0.9"/>
+<text x="-2.54" y="1.27" size="0.4064" layer="25">&gt;Name</text>
+<text x="-2.032" y="-0.254" size="0.6096" layer="21">&gt;Value</text>
+</package>
+<package name="SOT23-R" urn="urn:adsk.eagle:footprint:6240103/1" library_version="2">
+<description>&lt;b&gt;SOT23&lt;/b&gt; - Reflow soldering</description>
+<wire x1="1.5724" y1="0.6604" x2="1.5724" y2="-0.6604" width="0.1524" layer="51"/>
+<wire x1="1.5724" y1="-0.6604" x2="-1.5724" y2="-0.6604" width="0.1524" layer="51"/>
+<wire x1="-1.5724" y1="-0.6604" x2="-1.5724" y2="0.6604" width="0.1524" layer="51"/>
+<wire x1="-1.5724" y1="0.6604" x2="1.5724" y2="0.6604" width="0.1524" layer="51"/>
+<wire x1="-1.5724" y1="-0.6524" x2="-1.5724" y2="0.6604" width="0.1524" layer="21"/>
+<wire x1="-1.5724" y1="0.6604" x2="-0.5136" y2="0.6604" width="0.1524" layer="21"/>
+<wire x1="1.5724" y1="0.6604" x2="1.5724" y2="-0.6524" width="0.1524" layer="21"/>
+<wire x1="0.5636" y1="0.6604" x2="1.5724" y2="0.6604" width="0.1524" layer="21"/>
+<wire x1="0.4224" y1="-0.6604" x2="-0.4364" y2="-0.6604" width="0.1524" layer="21"/>
+<smd name="3" x="0" y="1" dx="0.6" dy="0.7" layer="1"/>
+<smd name="2" x="0.95" y="-1" dx="0.6" dy="0.7" layer="1"/>
+<smd name="1" x="-0.95" y="-1" dx="0.6" dy="0.7" layer="1"/>
+<text x="1.778" y="0.254" size="0.4064" layer="25">&gt;NAME</text>
+<text x="1.778" y="-0.508" size="0.4064" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.2286" y1="0.7112" x2="0.2286" y2="1.2954" layer="51"/>
+<rectangle x1="0.7112" y1="-1.2954" x2="1.1684" y2="-0.7112" layer="51"/>
+<rectangle x1="-1.1684" y1="-1.2954" x2="-0.7112" y2="-0.7112" layer="51"/>
+</package>
+<package name="SOT23-W" urn="urn:adsk.eagle:footprint:6240104/1" library_version="2">
+<description>&lt;b&gt;SOT23&lt;/b&gt; - Wave soldering</description>
+<wire x1="1.5724" y1="0.6604" x2="1.5724" y2="-0.6604" width="0.1524" layer="51"/>
+<wire x1="1.5724" y1="-0.6604" x2="-1.5724" y2="-0.6604" width="0.1524" layer="51"/>
+<wire x1="-1.5724" y1="-0.6604" x2="-1.5724" y2="0.6604" width="0.1524" layer="51"/>
+<wire x1="-1.5724" y1="0.6604" x2="1.5724" y2="0.6604" width="0.1524" layer="51"/>
+<wire x1="-1.5724" y1="-0.3984" x2="-1.5724" y2="0.6604" width="0.1524" layer="21"/>
+<wire x1="1.5724" y1="0.6604" x2="1.5724" y2="-0.3984" width="0.1524" layer="21"/>
+<wire x1="0.2954" y1="-0.6604" x2="-0.3094" y2="-0.6604" width="0.1524" layer="21"/>
+<smd name="3" x="0" y="1.3" dx="2.8" dy="1.4" layer="1"/>
+<smd name="2" x="1.1" y="-1.3" dx="1.2" dy="1.4" layer="1"/>
+<smd name="1" x="-1.1" y="-1.3" dx="1.2" dy="1.4" layer="1"/>
+<text x="2.032" y="0.254" size="0.4064" layer="25">&gt;NAME</text>
+<text x="2.032" y="-0.508" size="0.4064" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.2286" y1="0.7112" x2="0.2286" y2="1.2954" layer="51"/>
+<rectangle x1="0.7112" y1="-1.2954" x2="1.1684" y2="-0.7112" layer="51"/>
+<rectangle x1="-1.1684" y1="-1.2954" x2="-0.7112" y2="-0.7112" layer="51"/>
+</package>
+<package name="SOD-523" urn="urn:adsk.eagle:footprint:6240105/1" library_version="2">
+<description>SOD-523 (0.8x1.2mm)
+
+&lt;p&gt;Source: http://www.rohm.com/products/databook/di/pdf/rb751s-40.pdf&lt;/p&gt;</description>
+<wire x1="-0.75" y1="1.5" x2="0.75" y2="1.5" width="0.127" layer="21"/>
+<wire x1="0.75" y1="1.5" x2="0.75" y2="-1.5" width="0.127" layer="21"/>
+<wire x1="0.75" y1="-1.5" x2="-0.75" y2="-1.5" width="0.127" layer="21"/>
+<wire x1="-0.75" y1="-1.5" x2="-0.75" y2="1.5" width="0.127" layer="21"/>
+<wire x1="1" y1="0.25" x2="1.5" y2="0.25" width="0.127" layer="51"/>
+<wire x1="1.5" y1="0.25" x2="2" y2="0.25" width="0.127" layer="51"/>
+<wire x1="1" y1="-0.25" x2="1.5" y2="-0.25" width="0.127" layer="51"/>
+<wire x1="1.5" y1="-0.25" x2="2" y2="-0.25" width="0.127" layer="51"/>
+<wire x1="2" y1="-0.25" x2="1.5" y2="0.25" width="0.127" layer="51"/>
+<wire x1="1.5" y1="0.25" x2="1" y2="-0.25" width="0.127" layer="51"/>
+<wire x1="1.5" y1="0.25" x2="1.5" y2="0.75" width="0.127" layer="51"/>
+<wire x1="1.5" y1="-0.25" x2="1.5" y2="-0.75" width="0.127" layer="51"/>
+<wire x1="-0.4445" y1="-0.1905" x2="0.4445" y2="-0.1905" width="0.127" layer="21"/>
+<wire x1="0.4445" y1="-0.1905" x2="0" y2="0.1905" width="0.127" layer="21"/>
+<wire x1="0" y1="0.1905" x2="-0.4445" y2="-0.1905" width="0.127" layer="21"/>
+<wire x1="-0.4445" y1="0.1905" x2="0.4445" y2="0.1905" width="0.127" layer="21"/>
+<smd name="K" x="0" y="0.8" dx="0.8" dy="0.6" layer="1"/>
+<smd name="A" x="0" y="-0.8" dx="0.8" dy="0.6" layer="1"/>
+<text x="1.016" y="1.016" size="0.4064" layer="25">&gt;NAME</text>
+<text x="1.016" y="-1.524" size="0.4064" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.4" y1="-0.6" x2="0.4" y2="0.6" layer="51"/>
+<rectangle x1="-0.15" y1="-0.8" x2="0.15" y2="-0.6" layer="51"/>
+<rectangle x1="-0.15" y1="0.6" x2="0.15" y2="0.8" layer="51"/>
+</package>
+<package name="SOD-123" urn="urn:adsk.eagle:footprint:6240107/1" library_version="2">
+<wire x1="-1" y1="0.7" x2="1" y2="0.7" width="0.1524" layer="51"/>
+<wire x1="1" y1="0.7" x2="1" y2="-0.7" width="0.1524" layer="51"/>
+<wire x1="1" y1="-0.7" x2="-1" y2="-0.7" width="0.1524" layer="51"/>
+<wire x1="-1" y1="-0.7" x2="-1" y2="0.7" width="0.1524" layer="51"/>
+<wire x1="-0.5" y1="0" x2="0.1" y2="0.4" width="0.1524" layer="51"/>
+<wire x1="0.1" y1="0.4" x2="0.1" y2="-0.4" width="0.1524" layer="51"/>
+<wire x1="0.1" y1="-0.4" x2="-0.5" y2="0" width="0.1524" layer="51"/>
+<wire x1="-1.778" y1="0.762" x2="1.778" y2="0.762" width="0.127" layer="21"/>
+<wire x1="1.778" y1="0.762" x2="1.778" y2="-0.762" width="0.127" layer="21"/>
+<wire x1="1.778" y1="-0.762" x2="-1.778" y2="-0.762" width="0.127" layer="21"/>
+<wire x1="-1.778" y1="-0.762" x2="-1.778" y2="0.762" width="0.127" layer="21"/>
+<smd name="C" x="-1.85" y="0" dx="1.2" dy="0.7" layer="1"/>
+<smd name="A" x="1.85" y="0" dx="1.2" dy="0.7" layer="1"/>
+<text x="-1.1" y="1" size="0.4064" layer="25">&gt;NAME</text>
+<text x="-1.1" y="-1.284" size="0.4064" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.7" y1="-0.7" x2="-0.5" y2="0.7" layer="51"/>
+</package>
+<package name="SOD-323F" urn="urn:adsk.eagle:footprint:6240230/1" library_version="2">
+<wire x1="-0.85" y1="0.65" x2="0.85" y2="0.65" width="0.127" layer="21"/>
+<wire x1="0.85" y1="0.65" x2="0.85" y2="-0.65" width="0.127" layer="21"/>
+<wire x1="0.85" y1="-0.65" x2="-0.85" y2="-0.65" width="0.127" layer="21"/>
+<wire x1="-0.85" y1="-0.65" x2="-0.85" y2="0.65" width="0.127" layer="21"/>
+<wire x1="0.4" y1="0.6" x2="0.4" y2="-0.6" width="0.127" layer="21"/>
+<wire x1="0.4" y1="-0.6" x2="0.3" y2="-0.6" width="0.127" layer="21"/>
+<wire x1="0.3" y1="-0.6" x2="0.3" y2="0.6" width="0.127" layer="21"/>
+<wire x1="-0.9" y1="0.2" x2="-1.2" y2="0.2" width="0.127" layer="51"/>
+<wire x1="-1.2" y1="0.2" x2="-1.2" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="-1.2" y1="-0.2" x2="-0.9" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="0.9" y1="0.2" x2="1.2" y2="0.2" width="0.127" layer="51"/>
+<wire x1="1.2" y1="0.2" x2="1.2" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="1.2" y1="-0.2" x2="0.9" y2="-0.2" width="0.127" layer="51"/>
+<smd name="A" x="-1" y="0" dx="1" dy="0.8" layer="1"/>
+<smd name="C" x="1" y="0" dx="1" dy="0.8" layer="1"/>
+<text x="-1.8" y="0.9" size="0.8128" layer="25" font="vector">&gt;NAME</text>
+<text x="-2.1" y="-1.7" size="0.8128" layer="27" font="vector">&gt;VALUE</text>
+</package>
+<package name="SOD-123FL" urn="urn:adsk.eagle:footprint:6240294/1" library_version="2">
+<wire x1="-0.5" y1="0" x2="0.5" y2="0.4" width="0.1524" layer="21"/>
+<wire x1="0.5" y1="0.4" x2="0.5" y2="-0.4" width="0.1524" layer="21"/>
+<wire x1="0.5" y1="-0.4" x2="-0.5" y2="0" width="0.1524" layer="21"/>
+<wire x1="-1.35" y1="0.825" x2="1.35" y2="0.825" width="0.127" layer="21"/>
+<wire x1="1.35" y1="0.825" x2="1.35" y2="-0.825" width="0.127" layer="21"/>
+<wire x1="1.35" y1="-0.825" x2="-1.35" y2="-0.825" width="0.127" layer="21"/>
+<wire x1="-1.35" y1="-0.825" x2="-1.35" y2="0.825" width="0.127" layer="21"/>
+<smd name="C" x="-1.6375" y="0" dx="0.91" dy="1.22" layer="1"/>
+<smd name="A" x="1.6375" y="0" dx="0.91" dy="1.22" layer="1"/>
+<text x="-1.1" y="1" size="0.4064" layer="25">&gt;NAME</text>
+<text x="-1.1" y="-1.284" size="0.4064" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.7" y1="-0.7" x2="-0.5" y2="0.7" layer="21"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="SMADIODE" urn="urn:adsk.eagle:package:6240747/1" type="box" library_version="2">
+<description>&lt;b&gt;SMA Surface Mount Diode&lt;/b&gt;</description>
+<packageinstances>
+<packageinstance name="SMADIODE"/>
+</packageinstances>
+</package3d>
+<package3d name="DO-1N4148" urn="urn:adsk.eagle:package:6240748/1" type="box" library_version="2">
+<packageinstances>
+<packageinstance name="DO-1N4148"/>
+</packageinstances>
+</package3d>
+<package3d name="SOT23-R" urn="urn:adsk.eagle:package:6240749/1" type="box" library_version="2">
+<description>&lt;b&gt;SOT23&lt;/b&gt; - Reflow soldering</description>
+<packageinstances>
+<packageinstance name="SOT23-R"/>
+</packageinstances>
+</package3d>
+<package3d name="SOT23-W" urn="urn:adsk.eagle:package:6240750/1" type="box" library_version="2">
+<description>&lt;b&gt;SOT23&lt;/b&gt; - Wave soldering</description>
+<packageinstances>
+<packageinstance name="SOT23-W"/>
+</packageinstances>
+</package3d>
+<package3d name="SOD-523" urn="urn:adsk.eagle:package:6240751/1" type="box" library_version="2">
+<description>SOD-523 (0.8x1.2mm)
+
+&lt;p&gt;Source: http://www.rohm.com/products/databook/di/pdf/rb751s-40.pdf&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="SOD-523"/>
+</packageinstances>
+</package3d>
+<package3d name="SOD-123" urn="urn:adsk.eagle:package:6240753/1" type="box" library_version="2">
+<packageinstances>
+<packageinstance name="SOD-123"/>
+</packageinstances>
+</package3d>
+<package3d name="SOD-323F" urn="urn:adsk.eagle:package:6240873/1" type="box" library_version="2">
+<packageinstances>
+<packageinstance name="SOD-323F"/>
+</packageinstances>
+</package3d>
+<package3d name="SOD-123FL" urn="urn:adsk.eagle:package:6240937/1" type="box" library_version="2">
+<packageinstances>
+<packageinstance name="SOD-123FL"/>
+</packageinstances>
+</package3d>
+</packages3d>
+<symbols>
+<symbol name="DIODE" urn="urn:adsk.eagle:symbol:6239559/1" library_version="2">
+<wire x1="-1.27" y1="-1.27" x2="1.27" y2="0" width="0.254" layer="94"/>
+<wire x1="1.27" y1="0" x2="-1.27" y2="1.27" width="0.254" layer="94"/>
+<wire x1="1.27" y1="1.27" x2="1.27" y2="0" width="0.254" layer="94"/>
+<wire x1="-1.27" y1="1.27" x2="-1.27" y2="-1.27" width="0.254" layer="94"/>
+<wire x1="1.27" y1="0" x2="1.27" y2="-1.27" width="0.254" layer="94"/>
+<text x="-2.54" y="2.54" size="1.27" layer="95">&gt;NAME</text>
+<text x="-2.54" y="-3.81" size="1.27" layer="96">&gt;VALUE</text>
+<pin name="A" x="-2.54" y="0" visible="off" length="short" direction="pas"/>
+<pin name="C" x="2.54" y="0" visible="off" length="short" direction="pas" rot="R180"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="DIODE" urn="urn:adsk.eagle:component:6241050/1" prefix="D" uservalue="yes" library_version="2">
+<description>&lt;b&gt;Diode&lt;/b&gt;
+&lt;p&gt;
+&lt;b&gt;SMADIODE&lt;/b&gt; - SMA Surface Mount Package
+&lt;ul&gt;
+&lt;li&gt;20V 1A Schottky Diode Digikey: 641-1014-6-ND&lt;/li&gt;
+&lt;/ul&gt;
+&lt;b&gt;DO-1N4148&lt;/b&gt; - Through Hole Small Current Diode&lt;br&gt;
+&lt;b&gt;SOD-123&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;20V 1 A (.5mV Vf) Schottky Diode - Digikey: MBRX120TPMSCT-ND&lt;/li&gt;
+&lt;/ul&gt;
+&lt;b&gt;SOD-323&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;10V 570mA (.38mV Vf, 3ns) Schottky Diode - Digikey: ZLLS410CT-ND&lt;/li&gt;
+&lt;/ul&gt;
+&lt;b&gt;SOD-523&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;30V 30mA Schottky Diode (RB751S-40TE61) - Digikey: RB751S-40TE61CT-ND&lt;/li&gt;
+&lt;/ul&gt;
+&lt;b&gt;SOT23-R/W&lt;/b&gt; - SOT23 Package (R = Solder Paste/Reflow Ovens, W = Hand-Soldering)
+&lt;ul&gt;
+&lt;li&gt;BAT54Film 40V 300mA - Digikey: 497-7162-1-ND&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="DIODE" x="0" y="0"/>
+</gates>
+<devices>
+<device name="SMA" package="SMADIODE">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240747/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="DO-1N4148" package="DO-1N4148">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="SOT23_REFLOW" package="SOT23-R">
+<connects>
+<connect gate="G$1" pin="A" pad="1"/>
+<connect gate="G$1" pin="C" pad="3"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240749/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="SOT23_WAVE" package="SOT23-W">
+<connects>
+<connect gate="G$1" pin="A" pad="1"/>
+<connect gate="G$1" pin="C" pad="3"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240750/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="SOD-523" package="SOD-523">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="K"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240751/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="SOD-123" package="SOD-123">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240753/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="SOD-323F" package="SOD-323F">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240873/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SOD-123FL" package="SOD-123FL">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240937/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
 </libraries>
 <attributes>
 </attributes>
@@ -10825,17 +10895,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="D1" library="Components" deviceset="DIODE" device="-DFN0603-2">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
 <part name="SW02" library="Keyboard" deviceset="KEYSWITCH-PLAIN" device="-MX-1U">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
-<part name="D2" library="Components" deviceset="DIODE" device="-DFN0603-2">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -10845,17 +10905,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="D3" library="Components" deviceset="DIODE" device="-DFN0603-2">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
 <part name="SW04" library="Keyboard" deviceset="KEYSWITCH-PLAIN" device="-MX-1U">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
-<part name="D4" library="Components" deviceset="DIODE" device="-DFN0603-2">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -10865,17 +10915,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="D5" library="Components" deviceset="DIODE" device="-DFN0603-2">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
 <part name="SW06" library="Keyboard" deviceset="KEYSWITCH-PLAIN" device="-MX-1U">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
-<part name="D6" library="Components" deviceset="DIODE" device="-DFN0603-2">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -10885,17 +10925,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="D7" library="Components" deviceset="DIODE" device="-DFN0603-2">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
 <part name="SW08" library="Keyboard" deviceset="KEYSWITCH-PLAIN" device="-MX-1U">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
-<part name="D8" library="Components" deviceset="DIODE" device="-DFN0603-2">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -10905,17 +10935,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="D9" library="Components" deviceset="DIODE" device="-DFN0603-2">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
 <part name="SW10" library="Keyboard" deviceset="KEYSWITCH-PLAIN" device="-MX-1U">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
-<part name="D10" library="Components" deviceset="DIODE" device="-DFN0603-2">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -10925,17 +10945,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
-<part name="D11" library="Components" deviceset="DIODE" device="-DFN0603-2">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
 <part name="SW12" library="Keyboard" deviceset="KEYSWITCH-PLAIN" device="-MX-1U">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
-<part name="D12" library="Components" deviceset="DIODE" device="-DFN0603-2">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -11022,6 +11032,18 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
 <part name="SUPPLY2" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="GND" device=""/>
+<part name="D12" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D1" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D2" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D3" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D4" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D5" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D6" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D7" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D8" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D9" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D10" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="D11" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
 </parts>
 <sheets>
 <sheet>
@@ -11069,25 +11091,11 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MF" x="215.9" y="152.4" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="215.9" y="152.4" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="D1" gate="D$1" x="213.36" y="134.62" smashed="yes" rot="R270">
-<attribute name="NAME" x="216.0016" y="136.9314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="208.8642" y="137.1854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="213.36" y="134.62" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="213.36" y="134.62" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="213.36" y="134.62" size="1.778" layer="96" display="off"/>
-</instance>
 <instance part="SW02" gate="G$1" x="238.76" y="152.4" smashed="yes" rot="R180">
 <attribute name="NAME" x="245.57" y="147.082" size="1" layer="95" rot="R180"/>
 <attribute name="OC_NEWARK" x="238.76" y="152.4" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="238.76" y="152.4" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="238.76" y="152.4" size="1.778" layer="96" display="off"/>
-</instance>
-<instance part="D2" gate="D$1" x="236.22" y="134.62" smashed="yes" rot="R270">
-<attribute name="NAME" x="238.8616" y="136.9314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="231.7242" y="137.1854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="236.22" y="134.62" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="236.22" y="134.62" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="236.22" y="134.62" size="1.778" layer="96" display="off"/>
 </instance>
 <instance part="SW03" gate="G$1" x="261.62" y="152.4" smashed="yes" rot="R180">
 <attribute name="NAME" x="268.43" y="147.082" size="1" layer="95" rot="R180"/>
@@ -11095,25 +11103,11 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MF" x="261.62" y="152.4" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="261.62" y="152.4" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="D3" gate="D$1" x="259.08" y="134.62" smashed="yes" rot="R270">
-<attribute name="NAME" x="261.7216" y="136.9314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="254.5842" y="137.1854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="259.08" y="134.62" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="259.08" y="134.62" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="259.08" y="134.62" size="1.778" layer="96" display="off"/>
-</instance>
 <instance part="SW04" gate="G$1" x="215.9" y="114.3" smashed="yes" rot="R180">
 <attribute name="NAME" x="222.71" y="108.982" size="1" layer="95" rot="R180"/>
 <attribute name="OC_NEWARK" x="215.9" y="114.3" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="215.9" y="114.3" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="215.9" y="114.3" size="1.778" layer="96" display="off"/>
-</instance>
-<instance part="D4" gate="D$1" x="213.36" y="96.52" smashed="yes" rot="R270">
-<attribute name="NAME" x="216.0016" y="98.8314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="208.8642" y="99.0854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="213.36" y="96.52" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="213.36" y="96.52" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="213.36" y="96.52" size="1.778" layer="96" display="off"/>
 </instance>
 <instance part="SW05" gate="G$1" x="238.76" y="114.3" smashed="yes" rot="R180">
 <attribute name="NAME" x="245.57" y="108.982" size="1" layer="95" rot="R180"/>
@@ -11121,25 +11115,11 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MF" x="238.76" y="114.3" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="238.76" y="114.3" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="D5" gate="D$1" x="236.22" y="96.52" smashed="yes" rot="R270">
-<attribute name="NAME" x="238.8616" y="98.8314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="231.7242" y="99.0854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="236.22" y="96.52" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="236.22" y="96.52" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="236.22" y="96.52" size="1.778" layer="96" display="off"/>
-</instance>
 <instance part="SW06" gate="G$1" x="261.62" y="114.3" smashed="yes" rot="R180">
 <attribute name="NAME" x="268.43" y="108.982" size="1" layer="95" rot="R180"/>
 <attribute name="OC_NEWARK" x="261.62" y="114.3" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="261.62" y="114.3" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="261.62" y="114.3" size="1.778" layer="96" display="off"/>
-</instance>
-<instance part="D6" gate="D$1" x="259.08" y="96.52" smashed="yes" rot="R270">
-<attribute name="NAME" x="261.7216" y="98.8314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="254.5842" y="99.0854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="259.08" y="96.52" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="259.08" y="96.52" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="259.08" y="96.52" size="1.778" layer="96" display="off"/>
 </instance>
 <instance part="SW07" gate="G$1" x="215.9" y="76.2" smashed="yes" rot="R180">
 <attribute name="NAME" x="222.71" y="70.882" size="1" layer="95" rot="R180"/>
@@ -11147,25 +11127,11 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MF" x="215.9" y="76.2" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="215.9" y="76.2" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="D7" gate="D$1" x="213.36" y="58.42" smashed="yes" rot="R270">
-<attribute name="NAME" x="216.0016" y="60.7314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="208.8642" y="60.9854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="213.36" y="58.42" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="213.36" y="58.42" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="213.36" y="58.42" size="1.778" layer="96" display="off"/>
-</instance>
 <instance part="SW08" gate="G$1" x="238.76" y="76.2" smashed="yes" rot="R180">
 <attribute name="NAME" x="245.57" y="70.882" size="1" layer="95" rot="R180"/>
 <attribute name="OC_NEWARK" x="238.76" y="76.2" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="238.76" y="76.2" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="238.76" y="76.2" size="1.778" layer="96" display="off"/>
-</instance>
-<instance part="D8" gate="D$1" x="236.22" y="58.42" smashed="yes" rot="R270">
-<attribute name="NAME" x="238.8616" y="60.7314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="231.7242" y="60.9854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="236.22" y="58.42" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="236.22" y="58.42" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="236.22" y="58.42" size="1.778" layer="96" display="off"/>
 </instance>
 <instance part="SW09" gate="G$1" x="261.62" y="76.2" smashed="yes" rot="R180">
 <attribute name="NAME" x="268.43" y="70.882" size="1" layer="95" rot="R180"/>
@@ -11173,25 +11139,11 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MF" x="261.62" y="76.2" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="261.62" y="76.2" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="D9" gate="D$1" x="259.08" y="58.42" smashed="yes" rot="R270">
-<attribute name="NAME" x="261.7216" y="60.7314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="254.5842" y="60.9854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="259.08" y="58.42" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="259.08" y="58.42" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="259.08" y="58.42" size="1.778" layer="96" display="off"/>
-</instance>
 <instance part="SW10" gate="G$1" x="215.9" y="38.1" smashed="yes" rot="R180">
 <attribute name="NAME" x="222.71" y="32.782" size="1" layer="95" rot="R180"/>
 <attribute name="OC_NEWARK" x="215.9" y="38.1" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="215.9" y="38.1" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="215.9" y="38.1" size="1.778" layer="96" display="off"/>
-</instance>
-<instance part="D10" gate="D$1" x="213.36" y="20.32" smashed="yes" rot="R270">
-<attribute name="NAME" x="216.0016" y="22.6314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="208.8642" y="22.8854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="213.36" y="20.32" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="213.36" y="20.32" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="213.36" y="20.32" size="1.778" layer="96" display="off"/>
 </instance>
 <instance part="SW11" gate="G$1" x="238.76" y="38.1" smashed="yes" rot="R180">
 <attribute name="NAME" x="245.57" y="32.782" size="1" layer="95" rot="R180"/>
@@ -11199,25 +11151,11 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="MF" x="238.76" y="38.1" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="238.76" y="38.1" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="D11" gate="D$1" x="236.22" y="20.32" smashed="yes" rot="R270">
-<attribute name="NAME" x="238.8616" y="22.6314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="231.7242" y="22.8854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="236.22" y="20.32" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="236.22" y="20.32" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="236.22" y="20.32" size="1.778" layer="96" display="off"/>
-</instance>
 <instance part="SW12" gate="G$1" x="261.62" y="38.1" smashed="yes" rot="R180">
 <attribute name="NAME" x="268.43" y="32.782" size="1" layer="95" rot="R180"/>
 <attribute name="OC_NEWARK" x="261.62" y="38.1" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="261.62" y="38.1" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="261.62" y="38.1" size="1.778" layer="96" display="off"/>
-</instance>
-<instance part="D12" gate="D$1" x="259.08" y="20.32" smashed="yes" rot="R270">
-<attribute name="NAME" x="261.7216" y="22.6314" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="254.5842" y="22.8854" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="259.08" y="20.32" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="259.08" y="20.32" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="259.08" y="20.32" size="1.778" layer="96" display="off"/>
 </instance>
 <instance part="U$1" gate="G$1" x="127" y="63.5" smashed="yes">
 <attribute name="NAME" x="127" y="106.68" size="1.778" layer="95" font="vector" align="center"/>
@@ -11335,6 +11273,54 @@ In this library the device names are the same as the pin names of the symbols, t
 </instance>
 <instance part="SUPPLY2" gate="GND" x="20.32" y="-5.08" smashed="yes">
 <attribute name="VALUE" x="18.415" y="-8.255" size="1.778" layer="96"/>
+</instance>
+<instance part="D12" gate="G$1" x="259.08" y="20.32" smashed="yes" rot="R270">
+<attribute name="NAME" x="261.62" y="22.86" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="255.27" y="22.86" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D1" gate="G$1" x="213.36" y="134.62" smashed="yes" rot="R270">
+<attribute name="NAME" x="215.9" y="137.16" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="209.55" y="137.16" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D2" gate="G$1" x="236.22" y="134.62" smashed="yes" rot="R270">
+<attribute name="NAME" x="238.76" y="137.16" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="232.41" y="137.16" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D3" gate="G$1" x="259.08" y="134.62" smashed="yes" rot="R270">
+<attribute name="NAME" x="261.62" y="137.16" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="255.27" y="137.16" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D4" gate="G$1" x="213.36" y="96.52" smashed="yes" rot="R270">
+<attribute name="NAME" x="215.9" y="99.06" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="209.55" y="99.06" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D5" gate="G$1" x="236.22" y="96.52" smashed="yes" rot="R270">
+<attribute name="NAME" x="238.76" y="99.06" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="232.41" y="99.06" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D6" gate="G$1" x="259.08" y="96.52" smashed="yes" rot="R270">
+<attribute name="NAME" x="261.62" y="99.06" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="255.27" y="99.06" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D7" gate="G$1" x="213.36" y="58.42" smashed="yes" rot="R270">
+<attribute name="NAME" x="215.9" y="60.96" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="209.55" y="60.96" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D8" gate="G$1" x="236.22" y="58.42" smashed="yes" rot="R270">
+<attribute name="NAME" x="238.76" y="60.96" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="232.41" y="60.96" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D9" gate="G$1" x="259.08" y="58.42" smashed="yes" rot="R270">
+<attribute name="NAME" x="261.62" y="60.96" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="255.27" y="60.96" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D10" gate="G$1" x="213.36" y="20.32" smashed="yes" rot="R270">
+<attribute name="NAME" x="215.9" y="22.86" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="209.55" y="22.86" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="D11" gate="G$1" x="236.22" y="20.32" smashed="yes" rot="R270">
+<attribute name="NAME" x="238.76" y="22.86" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="232.41" y="22.86" size="1.27" layer="96" rot="R270"/>
 </instance>
 </instances>
 <busses>
@@ -11486,8 +11472,8 @@ In this library the device names are the same as the pin names of the symbols, t
 <net name="N$9" class="0">
 <segment>
 <pinref part="SW01" gate="G$1" pin="P1"/>
-<pinref part="D1" gate="D$1" pin="A"/>
-<wire x1="213.36" y1="142.24" x2="213.36" y2="139.7" width="0.1524" layer="91"/>
+<pinref part="D1" gate="G$1" pin="A"/>
+<wire x1="213.36" y1="142.24" x2="213.36" y2="137.16" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$10" class="0">
@@ -11516,19 +11502,13 @@ In this library the device names are the same as the pin names of the symbols, t
 <net name="N$12" class="0">
 <segment>
 <pinref part="SW02" gate="G$1" pin="P1"/>
-<pinref part="D2" gate="D$1" pin="A"/>
-<wire x1="236.22" y1="142.24" x2="236.22" y2="139.7" width="0.1524" layer="91"/>
+<pinref part="D2" gate="G$1" pin="A"/>
+<wire x1="236.22" y1="137.16" x2="236.22" y2="142.24" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$14" class="0">
 <segment>
-<pinref part="D2" gate="D$1" pin="C"/>
-<wire x1="236.22" y1="129.54" x2="236.22" y2="127" width="0.1524" layer="91"/>
-<pinref part="D3" gate="D$1" pin="C"/>
-<wire x1="259.08" y1="129.54" x2="259.08" y2="127" width="0.1524" layer="91"/>
 <wire x1="236.22" y1="127" x2="259.08" y2="127" width="0.1524" layer="91"/>
-<pinref part="D1" gate="D$1" pin="C"/>
-<wire x1="213.36" y1="129.54" x2="213.36" y2="127" width="0.1524" layer="91"/>
 <wire x1="236.22" y1="127" x2="213.36" y2="127" width="0.1524" layer="91"/>
 <junction x="213.36" y="127"/>
 <wire x1="213.36" y1="127" x2="187.96" y2="127" width="0.1524" layer="91"/>
@@ -11536,13 +11516,19 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="187.96" y1="127" x2="187.96" y2="68.58" width="0.1524" layer="91"/>
 <pinref part="U$1" gate="G$1" pin="PD4(ICP1/ADC8)"/>
 <wire x1="187.96" y1="68.58" x2="154.94" y2="68.58" width="0.1524" layer="91"/>
+<pinref part="D1" gate="G$1" pin="C"/>
+<wire x1="213.36" y1="132.08" x2="213.36" y2="127" width="0.1524" layer="91"/>
+<pinref part="D2" gate="G$1" pin="C"/>
+<wire x1="236.22" y1="132.08" x2="236.22" y2="127" width="0.1524" layer="91"/>
+<pinref part="D3" gate="G$1" pin="C"/>
+<wire x1="259.08" y1="132.08" x2="259.08" y2="127" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$15" class="0">
 <segment>
 <pinref part="SW03" gate="G$1" pin="P1"/>
-<pinref part="D3" gate="D$1" pin="A"/>
-<wire x1="259.08" y1="142.24" x2="259.08" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="259.08" y1="142.24" x2="259.08" y2="137.16" width="0.1524" layer="91"/>
+<pinref part="D3" gate="G$1" pin="A"/>
 </segment>
 </net>
 <net name="N$16" class="0">
@@ -11571,111 +11557,111 @@ In this library the device names are the same as the pin names of the symbols, t
 <net name="N$18" class="0">
 <segment>
 <pinref part="SW04" gate="G$1" pin="P1"/>
-<pinref part="D4" gate="D$1" pin="A"/>
-<wire x1="213.36" y1="104.14" x2="213.36" y2="101.6" width="0.1524" layer="91"/>
+<pinref part="D4" gate="G$1" pin="A"/>
+<wire x1="213.36" y1="104.14" x2="213.36" y2="99.06" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$21" class="0">
 <segment>
 <pinref part="SW05" gate="G$1" pin="P1"/>
-<pinref part="D5" gate="D$1" pin="A"/>
-<wire x1="236.22" y1="104.14" x2="236.22" y2="101.6" width="0.1524" layer="91"/>
+<pinref part="D5" gate="G$1" pin="A"/>
+<wire x1="236.22" y1="104.14" x2="236.22" y2="99.06" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$24" class="0">
 <segment>
 <pinref part="SW06" gate="G$1" pin="P1"/>
-<pinref part="D6" gate="D$1" pin="A"/>
-<wire x1="259.08" y1="104.14" x2="259.08" y2="101.6" width="0.1524" layer="91"/>
+<pinref part="D6" gate="G$1" pin="A"/>
+<wire x1="259.08" y1="104.14" x2="259.08" y2="99.06" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$26" class="0">
 <segment>
-<pinref part="D6" gate="D$1" pin="C"/>
-<wire x1="259.08" y1="91.44" x2="259.08" y2="88.9" width="0.1524" layer="91"/>
-<pinref part="D5" gate="D$1" pin="C"/>
-<wire x1="236.22" y1="91.44" x2="236.22" y2="88.9" width="0.1524" layer="91"/>
 <wire x1="259.08" y1="88.9" x2="236.22" y2="88.9" width="0.1524" layer="91"/>
 <junction x="236.22" y="88.9"/>
-<pinref part="D4" gate="D$1" pin="C"/>
-<wire x1="213.36" y1="91.44" x2="213.36" y2="88.9" width="0.1524" layer="91"/>
 <wire x1="236.22" y1="88.9" x2="213.36" y2="88.9" width="0.1524" layer="91"/>
 <junction x="213.36" y="88.9"/>
 <wire x1="213.36" y1="88.9" x2="185.42" y2="88.9" width="0.1524" layer="91"/>
 <pinref part="U$1" gate="G$1" pin="PD6(T1/ADC9/!OC4D)"/>
 <wire x1="185.42" y1="88.9" x2="185.42" y2="48.26" width="0.1524" layer="91"/>
 <wire x1="185.42" y1="48.26" x2="154.94" y2="48.26" width="0.1524" layer="91"/>
+<pinref part="D4" gate="G$1" pin="C"/>
+<wire x1="213.36" y1="93.98" x2="213.36" y2="88.9" width="0.1524" layer="91"/>
+<pinref part="D5" gate="G$1" pin="C"/>
+<wire x1="236.22" y1="93.98" x2="236.22" y2="88.9" width="0.1524" layer="91"/>
+<pinref part="D6" gate="G$1" pin="C"/>
+<wire x1="259.08" y1="93.98" x2="259.08" y2="88.9" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$27" class="0">
 <segment>
 <pinref part="SW07" gate="G$1" pin="P1"/>
-<pinref part="D7" gate="D$1" pin="A"/>
-<wire x1="213.36" y1="66.04" x2="213.36" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="D7" gate="G$1" pin="A"/>
+<wire x1="213.36" y1="60.96" x2="213.36" y2="66.04" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$30" class="0">
 <segment>
 <pinref part="SW08" gate="G$1" pin="P1"/>
-<pinref part="D8" gate="D$1" pin="A"/>
-<wire x1="236.22" y1="66.04" x2="236.22" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="D8" gate="G$1" pin="A"/>
+<wire x1="236.22" y1="60.96" x2="236.22" y2="66.04" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$32" class="0">
 <segment>
-<pinref part="D8" gate="D$1" pin="C"/>
-<wire x1="236.22" y1="53.34" x2="236.22" y2="50.8" width="0.1524" layer="91"/>
-<pinref part="D9" gate="D$1" pin="C"/>
-<wire x1="259.08" y1="53.34" x2="259.08" y2="50.8" width="0.1524" layer="91"/>
 <wire x1="236.22" y1="50.8" x2="259.08" y2="50.8" width="0.1524" layer="91"/>
 <junction x="236.22" y="50.8"/>
-<pinref part="D7" gate="D$1" pin="C"/>
-<wire x1="213.36" y1="53.34" x2="213.36" y2="50.8" width="0.1524" layer="91"/>
 <wire x1="236.22" y1="50.8" x2="213.36" y2="50.8" width="0.1524" layer="91"/>
 <junction x="213.36" y="50.8"/>
 <wire x1="213.36" y1="50.8" x2="190.5" y2="50.8" width="0.1524" layer="91"/>
 <wire x1="190.5" y1="50.8" x2="190.5" y2="63.5" width="0.1524" layer="91"/>
 <pinref part="U$1" gate="G$1" pin="PD7(T0/OC4D/ADC10)"/>
 <wire x1="190.5" y1="63.5" x2="154.94" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="D9" gate="G$1" pin="C"/>
+<wire x1="259.08" y1="50.8" x2="259.08" y2="55.88" width="0.1524" layer="91"/>
+<pinref part="D8" gate="G$1" pin="C"/>
+<wire x1="236.22" y1="55.88" x2="236.22" y2="50.8" width="0.1524" layer="91"/>
+<pinref part="D7" gate="G$1" pin="C"/>
+<wire x1="213.36" y1="55.88" x2="213.36" y2="50.8" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$33" class="0">
 <segment>
 <pinref part="SW09" gate="G$1" pin="P1"/>
-<pinref part="D9" gate="D$1" pin="A"/>
-<wire x1="259.08" y1="66.04" x2="259.08" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="D9" gate="G$1" pin="A"/>
+<wire x1="259.08" y1="60.96" x2="259.08" y2="66.04" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$36" class="0">
 <segment>
 <pinref part="SW10" gate="G$1" pin="P1"/>
-<pinref part="D10" gate="D$1" pin="A"/>
-<wire x1="213.36" y1="27.94" x2="213.36" y2="25.4" width="0.1524" layer="91"/>
+<pinref part="D10" gate="G$1" pin="A"/>
+<wire x1="213.36" y1="22.86" x2="213.36" y2="27.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$38" class="0">
 <segment>
-<pinref part="D10" gate="D$1" pin="C"/>
-<wire x1="213.36" y1="15.24" x2="213.36" y2="12.7" width="0.1524" layer="91"/>
-<pinref part="D11" gate="D$1" pin="C"/>
-<wire x1="236.22" y1="15.24" x2="236.22" y2="12.7" width="0.1524" layer="91"/>
 <wire x1="213.36" y1="12.7" x2="236.22" y2="12.7" width="0.1524" layer="91"/>
 <junction x="213.36" y="12.7"/>
-<pinref part="D12" gate="D$1" pin="C"/>
-<wire x1="259.08" y1="15.24" x2="259.08" y2="12.7" width="0.1524" layer="91"/>
 <wire x1="236.22" y1="12.7" x2="259.08" y2="12.7" width="0.1524" layer="91"/>
 <junction x="236.22" y="12.7"/>
 <wire x1="213.36" y1="12.7" x2="187.96" y2="12.7" width="0.1524" layer="91"/>
 <pinref part="U$1" gate="G$1" pin="PB4(PCINT4/ADC11)"/>
 <wire x1="154.94" y1="58.42" x2="187.96" y2="58.42" width="0.1524" layer="91"/>
 <wire x1="187.96" y1="58.42" x2="187.96" y2="12.7" width="0.1524" layer="91"/>
+<pinref part="D10" gate="G$1" pin="C"/>
+<wire x1="213.36" y1="17.78" x2="213.36" y2="12.7" width="0.1524" layer="91"/>
+<pinref part="D11" gate="G$1" pin="C"/>
+<wire x1="236.22" y1="12.7" x2="236.22" y2="17.78" width="0.1524" layer="91"/>
+<pinref part="D12" gate="G$1" pin="C"/>
+<wire x1="259.08" y1="17.78" x2="259.08" y2="12.7" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$39" class="0">
 <segment>
 <pinref part="SW11" gate="G$1" pin="P1"/>
-<pinref part="D11" gate="D$1" pin="A"/>
-<wire x1="236.22" y1="27.94" x2="236.22" y2="25.4" width="0.1524" layer="91"/>
+<pinref part="D11" gate="G$1" pin="A"/>
+<wire x1="236.22" y1="22.86" x2="236.22" y2="27.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$40" class="0">
@@ -11704,8 +11690,8 @@ In this library the device names are the same as the pin names of the symbols, t
 <net name="N$42" class="0">
 <segment>
 <pinref part="SW12" gate="G$1" pin="P1"/>
-<pinref part="D12" gate="D$1" pin="A"/>
-<wire x1="259.08" y1="27.94" x2="259.08" y2="25.4" width="0.1524" layer="91"/>
+<pinref part="D12" gate="G$1" pin="A"/>
+<wire x1="259.08" y1="27.94" x2="259.08" y2="22.86" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$4" class="0">
@@ -11826,6 +11812,11 @@ with this version.
 Since Version 8.3, EAGLE supports URNs for individual library
 assets (packages, symbols, and devices). The URNs of those assets
 will not be understood (or retained) with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports the association of 3D packages
+with devices in libraries, schematics, and board files. Those 3D
+packages will not be understood (or retained) with this version.
 </note>
 </compatibility>
 </eagle>

--- a/PCB/MacroPad.sch
+++ b/PCB/MacroPad.sch
@@ -11680,9 +11680,9 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="243.84" y1="60.96" x2="243.84" y2="22.86" width="0.1524" layer="91"/>
 <junction x="243.84" y="60.96"/>
 <wire x1="210.82" y1="160.02" x2="243.84" y2="160.02" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="PB5"/>
-<wire x1="210.82" y1="91.44" x2="210.82" y2="160.02" width="0.1524" layer="91"/>
-<wire x1="170.18" y1="91.44" x2="210.82" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="210.82" y1="81.28" x2="210.82" y2="160.02" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PC6"/>
+<wire x1="170.18" y1="81.28" x2="210.82" y2="81.28" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$12" class="0">
@@ -11735,9 +11735,9 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="289.56" y1="60.96" x2="289.56" y2="22.86" width="0.1524" layer="91"/>
 <junction x="289.56" y="60.96"/>
 <wire x1="205.74" y1="165.1" x2="289.56" y2="165.1" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="PC6"/>
-<wire x1="170.18" y1="81.28" x2="205.74" y2="81.28" width="0.1524" layer="91"/>
-<wire x1="205.74" y1="81.28" x2="205.74" y2="165.1" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PB5"/>
+<wire x1="205.74" y1="91.44" x2="205.74" y2="165.1" width="0.1524" layer="91"/>
+<wire x1="170.18" y1="91.44" x2="205.74" y2="91.44" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$18" class="0">

--- a/PCB/MacroPad.sch
+++ b/PCB/MacroPad.sch
@@ -10696,7 +10696,7 @@ In this library the device names are the same as the pin names of the symbols, t
 </deviceset>
 </devicesets>
 </library>
-<library name="ATMEGA32U4-AUR">
+<library name="ATMEGA32U4-AU">
 <packages>
 <package name="QFP80P1200X1200X120-44N">
 <wire x1="-4.572" y1="5.0546" x2="-5.0546" y2="5.0546" width="0.1524" layer="21"/>
@@ -10888,8 +10888,8 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="5.0546" y1="-5.0546" x2="5.0546" y2="5.0546" width="0" layer="51"/>
 <wire x1="5.0546" y1="5.0546" x2="-5.0546" y2="5.0546" width="0" layer="51"/>
 <wire x1="-5.0546" y1="5.0546" x2="-5.0546" y2="-5.0546" width="0" layer="51"/>
-<text x="-4.17045" y="-10.0955" size="2.08521875" layer="25" ratio="10" rot="SR0">&gt;NAME</text>
-<text x="-3.46611875" y="10.118" size="2.089859375" layer="27" ratio="10" rot="SR0">&gt;VALUE</text>
+<text x="-4.16611875" y="-10.0851" size="2.083059375" layer="25" ratio="10" rot="SR0">&gt;NAME</text>
+<text x="-3.45928125" y="10.098" size="2.085740625" layer="27" ratio="10" rot="SR0">&gt;VALUE</text>
 <smd name="1" x="-5.7404" y="3.9878" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
 <smd name="2" x="-5.7404" y="3.2004" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
 <smd name="3" x="-5.7404" y="2.3876" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
@@ -10937,13 +10937,13 @@ In this library the device names are the same as the pin names of the symbols, t
 </package>
 </packages>
 <symbols>
-<symbol name="ATMEGA32U4-AUR">
+<symbol name="ATMEGA32U4-AU">
 <wire x1="-12.7" y1="33.02" x2="-12.7" y2="-40.64" width="0.4064" layer="94"/>
 <wire x1="-12.7" y1="-40.64" x2="12.7" y2="-40.64" width="0.4064" layer="94"/>
 <wire x1="12.7" y1="-40.64" x2="12.7" y2="33.02" width="0.4064" layer="94"/>
 <wire x1="12.7" y1="33.02" x2="-12.7" y2="33.02" width="0.4064" layer="94"/>
-<text x="-5.802640625" y="34.5105" size="2.08691875" layer="95" ratio="10" rot="SR0">&gt;NAME</text>
-<text x="-3.63723125" y="-43.6467" size="2.085690625" layer="96" ratio="10" rot="SR0">&gt;VALUE</text>
+<text x="-5.797440625" y="34.4795" size="2.085040625" layer="95" ratio="10" rot="SR0">&gt;NAME</text>
+<text x="-3.63385" y="-43.6062" size="2.08375" layer="96" ratio="10" rot="SR0">&gt;VALUE</text>
 <pin name="VCC_2" x="-17.78" y="27.94" length="middle" direction="pwr"/>
 <pin name="VCC" x="-17.78" y="25.4" length="middle" direction="pwr"/>
 <pin name="UVCC" x="-17.78" y="22.86" length="middle" direction="pwr"/>
@@ -10991,10 +10991,10 @@ In this library the device names are the same as the pin names of the symbols, t
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="ATMEGA32U4-AUR" prefix="U">
+<deviceset name="ATMEGA32U4-AU" prefix="U">
 <description>8-bit Microcontroller with ISP Flash and USB Controller</description>
 <gates>
-<gate name="A" symbol="ATMEGA32U4-AUR" x="0" y="0"/>
+<gate name="A" symbol="ATMEGA32U4-AU" x="0" y="0"/>
 </gates>
 <devices>
 <device name="" package="QFP80P1200X1200X120-44N">
@@ -11047,9 +11047,9 @@ In this library the device names are the same as the pin names of the symbols, t
 <technologies>
 <technology name="">
 <attribute name="AVAILABILITY" value="Unavailable"/>
-<attribute name="DESCRIPTION" value=" ATmega Series 16 MHz 32 KB Flash 2.5 KB SRAM 8-Bit Microcontroller - TQFP-44 "/>
+<attribute name="DESCRIPTION" value=" MCU 8-bit ATmega AVR RISC 32KB Flash 3.3V/5V 44-Pin TQFP "/>
 <attribute name="MF" value="Microchip"/>
-<attribute name="MP" value="ATMEGA32U4-AUR"/>
+<attribute name="MP" value="ATMEGA32U4-AU"/>
 <attribute name="PACKAGE" value="TQFP-44 Microchip"/>
 <attribute name="PRICE" value="None"/>
 </technology>
@@ -11230,9 +11230,9 @@ In this library the device names are the same as the pin names of the symbols, t
 <part name="D9" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
 <part name="D10" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
 <part name="D11" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
-<part name="U1" library="ATMEGA32U4-AUR" deviceset="ATMEGA32U4-AUR" device=""/>
 <part name="SUPPLY9" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="GND" device=""/>
 <part name="Y1" library="Controller" deviceset="CRYSTAL-4PIN" device="-3.2X5"/>
+<part name="U1" library="ATMEGA32U4-AU" deviceset="ATMEGA32U4-AU" device=""/>
 </parts>
 <sheets>
 <sheet>
@@ -11497,16 +11497,16 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="NAME" x="254" y="10.16" size="1.27" layer="95" rot="R270"/>
 <attribute name="VALUE" x="247.65" y="10.16" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="U1" gate="A" x="152.4" y="76.2" smashed="yes">
-<attribute name="NAME" x="146.597359375" y="110.7105" size="2.08691875" layer="95" ratio="10" rot="SR0"/>
-<attribute name="VALUE" x="148.76276875" y="32.5533" size="2.085690625" layer="96" ratio="10" rot="SR0"/>
-</instance>
 <instance part="SUPPLY9" gate="GND" x="116.84" y="33.02" smashed="yes">
 <attribute name="VALUE" x="114.935" y="29.845" size="1.778" layer="96"/>
 </instance>
 <instance part="Y1" gate="G$1" x="104.14" y="33.02" smashed="yes" rot="R270">
 <attribute name="NAME" x="106.68" y="35.56" size="1.778" layer="95" font="vector" rot="R270" align="bottom-center"/>
 <attribute name="VALUE" x="109.22" y="35.56" size="1.778" layer="96" font="vector" rot="R270" align="bottom-center"/>
+</instance>
+<instance part="U1" gate="A" x="152.4" y="76.2" smashed="yes">
+<attribute name="NAME" x="146.602559375" y="110.6795" size="2.085040625" layer="95" ratio="10" rot="SR0"/>
+<attribute name="VALUE" x="148.76615" y="32.5938" size="2.08375" layer="96" ratio="10" rot="SR0"/>
 </instance>
 </instances>
 <busses>
@@ -11518,11 +11518,11 @@ In this library the device names are the same as the pin names of the symbols, t
 <junction x="104.14" y="27.94"/>
 <wire x1="101.6" y1="27.94" x2="104.14" y2="27.94" width="0.1524" layer="91"/>
 <pinref part="C2" gate="G$1" pin="2"/>
-<pinref part="U1" gate="A" pin="XTAL2"/>
 <wire x1="170.18" y1="43.18" x2="177.8" y2="43.18" width="0.1524" layer="91"/>
 <wire x1="177.8" y1="43.18" x2="177.8" y2="27.94" width="0.1524" layer="91"/>
 <wire x1="177.8" y1="27.94" x2="104.14" y2="27.94" width="0.1524" layer="91"/>
 <pinref part="Y1" gate="G$1" pin="2"/>
+<pinref part="U1" gate="A" pin="XTAL2"/>
 </segment>
 </net>
 <net name="N$2" class="0">
@@ -11532,9 +11532,9 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="104.14" y1="40.64" x2="104.14" y2="43.18" width="0.1524" layer="91"/>
 <junction x="104.14" y="43.18"/>
 <pinref part="C1" gate="G$1" pin="2"/>
-<pinref part="U1" gate="A" pin="XTAL1"/>
 <wire x1="104.14" y1="78.74" x2="134.62" y2="78.74" width="0.1524" layer="91"/>
 <pinref part="Y1" gate="G$1" pin="1"/>
+<pinref part="U1" gate="A" pin="XTAL1"/>
 </segment>
 </net>
 <net name="VCC" class="0">
@@ -11574,33 +11574,32 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="101.6" y1="96.52" x2="101.6" y2="93.98" width="0.1524" layer="91"/>
 <wire x1="101.6" y1="96.52" x2="127" y2="96.52" width="0.1524" layer="91"/>
 <wire x1="127" y1="96.52" x2="127" y2="99.06" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="VCC_2"/>
 <wire x1="127" y1="99.06" x2="127" y2="101.6" width="0.1524" layer="91"/>
 <wire x1="127" y1="101.6" x2="127" y2="104.14" width="0.1524" layer="91"/>
 <wire x1="127" y1="104.14" x2="134.62" y2="104.14" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="VCC"/>
 <wire x1="134.62" y1="101.6" x2="127" y2="101.6" width="0.1524" layer="91"/>
 <junction x="127" y="101.6"/>
-<pinref part="U1" gate="A" pin="AVCC_2"/>
 <wire x1="134.62" y1="96.52" x2="127" y2="96.52" width="0.1524" layer="91"/>
 <junction x="127" y="96.52"/>
-<pinref part="U1" gate="A" pin="AVCC"/>
 <wire x1="134.62" y1="93.98" x2="127" y2="93.98" width="0.1524" layer="91"/>
 <wire x1="127" y1="93.98" x2="127" y2="96.52" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="VBUS"/>
 <wire x1="134.62" y1="73.66" x2="127" y2="73.66" width="0.1524" layer="91"/>
 <wire x1="127" y1="73.66" x2="127" y2="93.98" width="0.1524" layer="91"/>
 <junction x="127" y="93.98"/>
-<pinref part="U1" gate="A" pin="UVCC"/>
 <wire x1="134.62" y1="99.06" x2="127" y2="99.06" width="0.1524" layer="91"/>
 <junction x="127" y="99.06"/>
+<pinref part="U1" gate="A" pin="VCC_2"/>
+<pinref part="U1" gate="A" pin="VCC"/>
+<pinref part="U1" gate="A" pin="UVCC"/>
+<pinref part="U1" gate="A" pin="AVCC_2"/>
+<pinref part="U1" gate="A" pin="AVCC"/>
+<pinref part="U1" gate="A" pin="VBUS"/>
 </segment>
 </net>
 <net name="N$3" class="0">
 <segment>
 <pinref part="RESET" gate="G$1" pin="2"/>
 <wire x1="96.52" y1="106.68" x2="99.06" y2="106.68" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="~RESET"/>
 <wire x1="99.06" y1="106.68" x2="104.14" y2="106.68" width="0.1524" layer="91"/>
 <wire x1="104.14" y1="106.68" x2="104.14" y2="81.28" width="0.1524" layer="91"/>
 <wire x1="104.14" y1="81.28" x2="134.62" y2="81.28" width="0.1524" layer="91"/>
@@ -11608,15 +11607,16 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="96.52" y1="114.3" x2="99.06" y2="114.3" width="0.1524" layer="91"/>
 <wire x1="99.06" y1="114.3" x2="99.06" y2="106.68" width="0.1524" layer="91"/>
 <junction x="99.06" y="106.68"/>
+<pinref part="U1" gate="A" pin="~RESET"/>
 </segment>
 </net>
 <net name="UCAP" class="0">
 <segment>
 <pinref part="C3" gate="G$1" pin="1"/>
-<pinref part="U1" gate="A" pin="UCAP"/>
 <wire x1="96.52" y1="76.2" x2="134.62" y2="76.2" width="0.1524" layer="91"/>
 <wire x1="93.98" y1="86.36" x2="96.52" y2="86.36" width="0.1524" layer="91"/>
 <wire x1="96.52" y1="86.36" x2="96.52" y2="76.2" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="UCAP"/>
 </segment>
 </net>
 <net name="N$5" class="0">
@@ -11651,8 +11651,8 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="81.28" y1="88.9" x2="99.06" y2="88.9" width="0.1524" layer="91"/>
 <wire x1="99.06" y1="88.9" x2="99.06" y2="86.36" width="0.1524" layer="91"/>
 <pinref part="R3" gate="G$1" pin="2"/>
-<pinref part="U1" gate="A" pin="D+"/>
 <wire x1="134.62" y1="86.36" x2="99.06" y2="86.36" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="D+"/>
 </segment>
 </net>
 <net name="N$9" class="0">
@@ -11681,8 +11681,8 @@ In this library the device names are the same as the pin names of the symbols, t
 <junction x="243.84" y="60.96"/>
 <wire x1="210.82" y1="160.02" x2="243.84" y2="160.02" width="0.1524" layer="91"/>
 <wire x1="210.82" y1="81.28" x2="210.82" y2="160.02" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="PC6"/>
 <wire x1="170.18" y1="81.28" x2="210.82" y2="81.28" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PC6"/>
 </segment>
 </net>
 <net name="N$12" class="0">
@@ -11706,8 +11706,8 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="251.46" y1="119.38" x2="251.46" y2="114.3" width="0.1524" layer="91"/>
 <pinref part="D3" gate="G$1" pin="C"/>
 <wire x1="274.32" y1="119.38" x2="274.32" y2="114.3" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="PD4"/>
 <wire x1="170.18" y1="63.5" x2="203.2" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PD4"/>
 </segment>
 </net>
 <net name="N$15" class="0">
@@ -11735,9 +11735,9 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="289.56" y1="60.96" x2="289.56" y2="22.86" width="0.1524" layer="91"/>
 <junction x="289.56" y="60.96"/>
 <wire x1="205.74" y1="165.1" x2="289.56" y2="165.1" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="PB5"/>
 <wire x1="205.74" y1="91.44" x2="205.74" y2="165.1" width="0.1524" layer="91"/>
 <wire x1="170.18" y1="91.44" x2="205.74" y2="91.44" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PB5"/>
 </segment>
 </net>
 <net name="N$18" class="0">
@@ -11774,9 +11774,9 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="251.46" y1="81.28" x2="251.46" y2="76.2" width="0.1524" layer="91"/>
 <pinref part="D6" gate="G$1" pin="C"/>
 <wire x1="274.32" y1="81.28" x2="274.32" y2="76.2" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="PD6"/>
 <wire x1="170.18" y1="58.42" x2="205.74" y2="58.42" width="0.1524" layer="91"/>
 <wire x1="205.74" y1="58.42" x2="205.74" y2="76.2" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PD6"/>
 </segment>
 </net>
 <net name="N$27" class="0">
@@ -11807,8 +11807,8 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="251.46" y1="43.18" x2="251.46" y2="38.1" width="0.1524" layer="91"/>
 <pinref part="D7" gate="G$1" pin="C"/>
 <wire x1="228.6" y1="43.18" x2="228.6" y2="38.1" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="PD7"/>
 <wire x1="170.18" y1="55.88" x2="205.74" y2="55.88" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PD7"/>
 </segment>
 </net>
 <net name="N$33" class="0">
@@ -11837,10 +11837,10 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="251.46" y1="0" x2="251.46" y2="5.08" width="0.1524" layer="91"/>
 <pinref part="D12" gate="G$1" pin="C"/>
 <wire x1="274.32" y1="5.08" x2="274.32" y2="0" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="PB4"/>
 <wire x1="170.18" y1="93.98" x2="200.66" y2="93.98" width="0.1524" layer="91"/>
 <wire x1="200.66" y1="93.98" x2="200.66" y2="0" width="0.1524" layer="91"/>
 <wire x1="200.66" y1="0" x2="228.6" y2="0" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PB4"/>
 </segment>
 </net>
 <net name="N$39" class="0">
@@ -11868,9 +11868,9 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="266.7" y1="22.86" x2="266.7" y2="60.96" width="0.1524" layer="91"/>
 <junction x="266.7" y="60.96"/>
 <wire x1="266.7" y1="162.56" x2="208.28" y2="162.56" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="PB6"/>
 <wire x1="170.18" y1="88.9" x2="208.28" y2="88.9" width="0.1524" layer="91"/>
 <wire x1="208.28" y1="88.9" x2="208.28" y2="162.56" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PB6"/>
 </segment>
 </net>
 <net name="N$42" class="0">
@@ -11882,10 +11882,10 @@ In this library the device names are the same as the pin names of the symbols, t
 </net>
 <net name="N$4" class="0">
 <segment>
-<pinref part="U1" gate="A" pin="PE2"/>
 <wire x1="170.18" y1="50.8" x2="187.96" y2="50.8" width="0.1524" layer="91"/>
 <wire x1="187.96" y1="50.8" x2="187.96" y2="48.26" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="2"/>
+<pinref part="U1" gate="A" pin="PE2"/>
 </segment>
 </net>
 <net name="N$11" class="0">
@@ -11963,24 +11963,24 @@ In this library the device names are the same as the pin names of the symbols, t
 <segment>
 <pinref part="SUPPLY9" gate="GND" pin="GND"/>
 <wire x1="116.84" y1="35.56" x2="116.84" y2="45.72" width="0.1524" layer="91"/>
-<pinref part="U1" gate="A" pin="GND_3"/>
-<pinref part="U1" gate="A" pin="GND_2"/>
 <wire x1="134.62" y1="50.8" x2="129.54" y2="50.8" width="0.1524" layer="91"/>
 <wire x1="129.54" y1="50.8" x2="129.54" y2="48.26" width="0.1524" layer="91"/>
 <wire x1="129.54" y1="48.26" x2="134.62" y2="48.26" width="0.1524" layer="91"/>
 <junction x="129.54" y="48.26"/>
-<pinref part="U1" gate="A" pin="GND_4"/>
 <wire x1="134.62" y1="45.72" x2="129.54" y2="45.72" width="0.1524" layer="91"/>
 <wire x1="129.54" y1="45.72" x2="129.54" y2="48.26" width="0.1524" layer="91"/>
 <junction x="129.54" y="45.72"/>
-<pinref part="U1" gate="A" pin="GND"/>
 <wire x1="134.62" y1="43.18" x2="129.54" y2="43.18" width="0.1524" layer="91"/>
 <wire x1="129.54" y1="43.18" x2="129.54" y2="45.72" width="0.1524" layer="91"/>
 <junction x="129.54" y="43.18"/>
-<pinref part="U1" gate="A" pin="UGND"/>
 <wire x1="134.62" y1="40.64" x2="129.54" y2="40.64" width="0.1524" layer="91"/>
 <wire x1="129.54" y1="40.64" x2="129.54" y2="43.18" width="0.1524" layer="91"/>
 <wire x1="116.84" y1="45.72" x2="129.54" y2="45.72" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="GND_2"/>
+<pinref part="U1" gate="A" pin="GND_3"/>
+<pinref part="U1" gate="A" pin="GND_4"/>
+<pinref part="U1" gate="A" pin="GND"/>
+<pinref part="U1" gate="A" pin="UGND"/>
 </segment>
 </net>
 </nets>

--- a/PCB/MacroPad.sch
+++ b/PCB/MacroPad.sch
@@ -336,63 +336,6 @@ Note- Available clearance varies from computer to computer. This distance has be
 <smd name="SHIELD@3" x="-5.08" y="3.81" dx="0.3048" dy="0.1524" layer="1"/>
 <smd name="SHIELD@4" x="-6.35" y="3.81" dx="0.3048" dy="0.1524" layer="1"/>
 </package>
-<package name="QFN-44">
-<description>QFN44 footprint</description>
-<wire x1="-4.135" y1="-4.135" x2="-4.135" y2="3.34443125" width="0.127" layer="21"/>
-<wire x1="-4.135" y1="3.34443125" x2="-3.34443125" y2="4.135" width="0.127" layer="21"/>
-<wire x1="-3.34443125" y1="4.135" x2="4.135" y2="4.135" width="0.127" layer="21"/>
-<wire x1="4.135" y1="4.135" x2="4.135" y2="-4.135" width="0.127" layer="21"/>
-<wire x1="4.135" y1="-4.135" x2="-4.135" y2="-4.135" width="0.127" layer="21"/>
-<smd name="TAB" x="0" y="0" dx="5.08" dy="5.08" layer="1" roundness="10"/>
-<smd name="1" x="-3.35" y="2.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="2" x="-3.35" y="2" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="3" x="-3.35" y="1.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="4" x="-3.35" y="1" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="5" x="-3.35" y="0.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="6" x="-3.35" y="0" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="7" x="-3.35" y="-0.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="8" x="-3.35" y="-1" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="9" x="-3.35" y="-1.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="10" x="-3.35" y="-2" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="11" x="-3.35" y="-2.5" dx="1" dy="0.3" layer="1" roundness="25" rot="R180"/>
-<smd name="12" x="-2.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="13" x="-2" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="14" x="-1.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="15" x="-1" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="16" x="-0.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="17" x="0" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="18" x="0.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="19" x="1" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="20" x="1.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="21" x="2" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="22" x="2.5" y="-3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R270"/>
-<smd name="23" x="3.35" y="-2.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="24" x="3.35" y="-2" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="25" x="3.35" y="-1.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="26" x="3.35" y="-1" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="27" x="3.35" y="-0.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="28" x="3.35" y="0" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="29" x="3.35" y="0.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="30" x="3.35" y="1" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="31" x="3.35" y="1.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="32" x="3.35" y="2" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="33" x="3.35" y="2.5" dx="1" dy="0.3" layer="1" roundness="25"/>
-<smd name="34" x="2.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="35" x="2" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="36" x="1.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="37" x="1" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="38" x="0.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="39" x="0" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="40" x="-0.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="41" x="-1" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="42" x="-1.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="43" x="-2" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<smd name="44" x="-2.5" y="3.35" dx="1" dy="0.3" layer="1" roundness="25" rot="R90"/>
-<circle x="-4.445" y="4.445" radius="0.381" width="0" layer="21"/>
-<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="39"/>
-<text x="-1.905" y="4.445" size="0.889" layer="25" ratio="11">&gt;NAME</text>
-<text x="-2.54" y="-5.08" size="0.889" layer="27" ratio="11">&gt;VALUE</text>
-</package>
 </packages>
 <symbols>
 <symbol name="USB">
@@ -427,58 +370,6 @@ Note- Available clearance varies from computer to computer. This distance has be
 <pin name="SHIELD@2" x="2.54" y="-12.7" length="middle" rot="R180"/>
 <pin name="SHIELD@3" x="2.54" y="-15.24" length="middle" rot="R180"/>
 <pin name="SHIELD@4" x="2.54" y="-17.78" length="middle" rot="R180"/>
-</symbol>
-<symbol name="ATMEGA32U4">
-<pin name="PE6(INT.6/AIN0)" x="27.94" y="-2.54" length="short" rot="R180"/>
-<pin name="UVCC" x="-30.48" y="22.86" length="short"/>
-<pin name="D-" x="-30.48" y="10.16" length="short"/>
-<pin name="D+" x="-30.48" y="7.62" length="short"/>
-<pin name="UGND" x="-30.48" y="-25.4" length="short"/>
-<pin name="UCAP" x="-30.48" y="20.32" length="short"/>
-<pin name="VBUS" x="-30.48" y="25.4" length="short"/>
-<pin name="PB0(SS/PCINT0)" x="27.94" y="-20.32" length="short" rot="R180"/>
-<pin name="PB1(PCINT1/SCLK)" x="27.94" y="-22.86" length="short" rot="R180"/>
-<pin name="PB2(PDI/PCINT2/MOSI)" x="27.94" y="-25.4" length="short" rot="R180"/>
-<pin name="PB3(PD0/PCINT3/MISO)" x="27.94" y="-27.94" length="short" rot="R180"/>
-<pin name="PB7(PCINT7/OC0A/OC1C/!RTS)" x="27.94" y="-12.7" length="short" rot="R180"/>
-<pin name="!RESET" x="-30.48" y="-12.7" length="short"/>
-<pin name="VCC@14" x="-30.48" y="38.1" length="short"/>
-<pin name="GND@15" x="-30.48" y="-27.94" length="short"/>
-<pin name="XTAL2" x="-30.48" y="-5.08" length="short"/>
-<pin name="XTAL1" x="-30.48" y="0" length="short"/>
-<pin name="PD0(OC0B/SCL/INT0)" x="27.94" y="7.62" length="short" rot="R180"/>
-<pin name="PD1(SDA/INT1)" x="27.94" y="10.16" length="short" rot="R180"/>
-<pin name="PD2(RXD1/INT2)" x="27.94" y="15.24" length="short" rot="R180"/>
-<pin name="PD3(TXD1/INT3)" x="27.94" y="12.7" length="short" rot="R180"/>
-<pin name="PD5(XCLK1/!CTS)" x="27.94" y="-33.02" length="short" rot="R180"/>
-<pin name="GND@23" x="-30.48" y="-30.48" length="short"/>
-<pin name="AVCC@24" x="-30.48" y="33.02" length="short"/>
-<pin name="PD4(ICP1/ADC8)" x="27.94" y="5.08" length="short" rot="R180"/>
-<pin name="PD6(T1/ADC9/!OC4D)" x="27.94" y="-15.24" length="short" rot="R180"/>
-<pin name="PD7(T0/OC4D/ADC10)" x="27.94" y="0" length="short" rot="R180"/>
-<pin name="PB4(PCINT4/ADC11)" x="27.94" y="-5.08" length="short" rot="R180"/>
-<pin name="PB5(PCINT5/OC1A/ADC12/!OC4B)" x="27.94" y="-7.62" length="short" rot="R180"/>
-<pin name="PB6(PCINT6/OC1B/OC4B/ADC13)" x="27.94" y="-10.16" length="short" rot="R180"/>
-<pin name="PC6(OC3A/!OC4A)" x="27.94" y="2.54" length="short" rot="R180"/>
-<pin name="PC7(ICP3/CLK0/OC4A)" x="27.94" y="-17.78" length="short" rot="R180"/>
-<pin name="PE2(!HWB)" x="-30.48" y="-17.78" length="short"/>
-<pin name="VCC@34" x="-30.48" y="35.56" length="short"/>
-<pin name="GND@35" x="-30.48" y="-33.02" length="short"/>
-<pin name="PF7(ADC7/TDI)" x="27.94" y="38.1" length="short" rot="R180"/>
-<pin name="PF6(ADC6/TDO)" x="27.94" y="35.56" length="short" rot="R180"/>
-<pin name="PF5(ADC5/TMS)" x="27.94" y="33.02" length="short" rot="R180"/>
-<pin name="PF4(ADC4/TCK)" x="27.94" y="30.48" length="short" rot="R180"/>
-<pin name="PF1(ADC1)" x="27.94" y="27.94" length="short" rot="R180"/>
-<pin name="PF0(ADC0)" x="27.94" y="25.4" length="short" rot="R180"/>
-<pin name="AREF" x="-30.48" y="27.94" length="short"/>
-<pin name="GND@43" x="-30.48" y="-35.56" length="short"/>
-<pin name="AVCC@44" x="-30.48" y="30.48" length="short"/>
-<text x="0" y="43.18" size="1.778" layer="95" font="vector" align="center">&gt;NAME</text>
-<text x="0" y="-40.64" size="1.778" layer="96" font="vector" align="center">&gt;VALUE</text>
-<wire x1="-27.94" y1="40.64" x2="25.4" y2="40.64" width="0.254" layer="94"/>
-<wire x1="25.4" y1="40.64" x2="25.4" y2="-38.1" width="0.254" layer="94"/>
-<wire x1="25.4" y1="-38.1" x2="-27.94" y2="-38.1" width="0.254" layer="94"/>
-<wire x1="-27.94" y1="-38.1" x2="-27.94" y2="40.64" width="0.254" layer="94"/>
 </symbol>
 </symbols>
 <devicesets>
@@ -530,64 +421,6 @@ Note- Available clearance varies from computer to computer. This distance has be
 <connect gate="G$1" pin="SHIELD@3" pad="SHIELD@3"/>
 <connect gate="G$1" pin="SHIELD@4" pad="SHIELD@4"/>
 <connect gate="G$1" pin="VCC" pad="5V"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="ATMEGA32U4">
-<gates>
-<gate name="G$1" symbol="ATMEGA32U4" x="0" y="0"/>
-</gates>
-<devices>
-<device name="-QFN44" package="QFN-44">
-<connects>
-<connect gate="G$1" pin="!RESET" pad="13"/>
-<connect gate="G$1" pin="AREF" pad="42"/>
-<connect gate="G$1" pin="AVCC@24" pad="24"/>
-<connect gate="G$1" pin="AVCC@44" pad="44"/>
-<connect gate="G$1" pin="D+" pad="4"/>
-<connect gate="G$1" pin="D-" pad="3"/>
-<connect gate="G$1" pin="GND@15" pad="15 TAB"/>
-<connect gate="G$1" pin="GND@23" pad="23"/>
-<connect gate="G$1" pin="GND@35" pad="35"/>
-<connect gate="G$1" pin="GND@43" pad="43"/>
-<connect gate="G$1" pin="PB0(SS/PCINT0)" pad="8"/>
-<connect gate="G$1" pin="PB1(PCINT1/SCLK)" pad="9"/>
-<connect gate="G$1" pin="PB2(PDI/PCINT2/MOSI)" pad="10"/>
-<connect gate="G$1" pin="PB3(PD0/PCINT3/MISO)" pad="11"/>
-<connect gate="G$1" pin="PB4(PCINT4/ADC11)" pad="28"/>
-<connect gate="G$1" pin="PB5(PCINT5/OC1A/ADC12/!OC4B)" pad="29"/>
-<connect gate="G$1" pin="PB6(PCINT6/OC1B/OC4B/ADC13)" pad="30"/>
-<connect gate="G$1" pin="PB7(PCINT7/OC0A/OC1C/!RTS)" pad="12"/>
-<connect gate="G$1" pin="PC6(OC3A/!OC4A)" pad="31"/>
-<connect gate="G$1" pin="PC7(ICP3/CLK0/OC4A)" pad="32"/>
-<connect gate="G$1" pin="PD0(OC0B/SCL/INT0)" pad="18"/>
-<connect gate="G$1" pin="PD1(SDA/INT1)" pad="19"/>
-<connect gate="G$1" pin="PD2(RXD1/INT2)" pad="20"/>
-<connect gate="G$1" pin="PD3(TXD1/INT3)" pad="21"/>
-<connect gate="G$1" pin="PD4(ICP1/ADC8)" pad="25"/>
-<connect gate="G$1" pin="PD5(XCLK1/!CTS)" pad="22"/>
-<connect gate="G$1" pin="PD6(T1/ADC9/!OC4D)" pad="26"/>
-<connect gate="G$1" pin="PD7(T0/OC4D/ADC10)" pad="27"/>
-<connect gate="G$1" pin="PE2(!HWB)" pad="33"/>
-<connect gate="G$1" pin="PE6(INT.6/AIN0)" pad="1"/>
-<connect gate="G$1" pin="PF0(ADC0)" pad="41"/>
-<connect gate="G$1" pin="PF1(ADC1)" pad="40"/>
-<connect gate="G$1" pin="PF4(ADC4/TCK)" pad="39"/>
-<connect gate="G$1" pin="PF5(ADC5/TMS)" pad="38"/>
-<connect gate="G$1" pin="PF6(ADC6/TDO)" pad="37"/>
-<connect gate="G$1" pin="PF7(ADC7/TDI)" pad="36"/>
-<connect gate="G$1" pin="UCAP" pad="6"/>
-<connect gate="G$1" pin="UGND" pad="5"/>
-<connect gate="G$1" pin="UVCC" pad="2"/>
-<connect gate="G$1" pin="VBUS" pad="7"/>
-<connect gate="G$1" pin="VCC@14" pad="14"/>
-<connect gate="G$1" pin="VCC@34" pad="34"/>
-<connect gate="G$1" pin="XTAL1" pad="17"/>
-<connect gate="G$1" pin="XTAL2" pad="16"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -10863,6 +10696,369 @@ In this library the device names are the same as the pin names of the symbols, t
 </deviceset>
 </devicesets>
 </library>
+<library name="ATMEGA32U4-AUR">
+<packages>
+<package name="QFP80P1200X1200X120-44N">
+<wire x1="-4.572" y1="5.0546" x2="-5.0546" y2="5.0546" width="0.1524" layer="21"/>
+<wire x1="5.0546" y1="4.572" x2="5.0546" y2="5.0546" width="0.1524" layer="21"/>
+<wire x1="4.572" y1="-5.0546" x2="5.0546" y2="-5.0546" width="0.1524" layer="21"/>
+<wire x1="-5.0546" y1="-5.0546" x2="-4.572" y2="-5.0546" width="0.1524" layer="21"/>
+<wire x1="5.0546" y1="-5.0546" x2="5.0546" y2="-4.572" width="0.1524" layer="21"/>
+<wire x1="5.0546" y1="5.0546" x2="4.572" y2="5.0546" width="0.1524" layer="21"/>
+<wire x1="-5.0546" y1="5.0546" x2="-5.0546" y2="4.572" width="0.1524" layer="21"/>
+<wire x1="-5.0546" y1="-4.572" x2="-5.0546" y2="-5.0546" width="0.1524" layer="21"/>
+<wire x1="3.7846" y1="5.0546" x2="4.2164" y2="5.0546" width="0" layer="51"/>
+<wire x1="4.2164" y1="5.0546" x2="4.2164" y2="6.1214" width="0" layer="51"/>
+<wire x1="4.2164" y1="6.1214" x2="3.7846" y2="6.1214" width="0" layer="51"/>
+<wire x1="3.7846" y1="6.1214" x2="3.7846" y2="5.0546" width="0" layer="51"/>
+<wire x1="2.9718" y1="5.0546" x2="3.429" y2="5.0546" width="0" layer="51"/>
+<wire x1="3.429" y1="5.0546" x2="3.429" y2="6.1214" width="0" layer="51"/>
+<wire x1="3.429" y1="6.1214" x2="2.9718" y2="6.1214" width="0" layer="51"/>
+<wire x1="2.9718" y1="6.1214" x2="2.9718" y2="5.0546" width="0" layer="51"/>
+<wire x1="2.1844" y1="5.0546" x2="2.6162" y2="5.0546" width="0" layer="51"/>
+<wire x1="2.6162" y1="5.0546" x2="2.6162" y2="6.1214" width="0" layer="51"/>
+<wire x1="2.6162" y1="6.1214" x2="2.1844" y2="6.1214" width="0" layer="51"/>
+<wire x1="2.1844" y1="6.1214" x2="2.1844" y2="5.0546" width="0" layer="51"/>
+<wire x1="1.3716" y1="5.0546" x2="1.8288" y2="5.0546" width="0" layer="51"/>
+<wire x1="1.8288" y1="5.0546" x2="1.8288" y2="6.1214" width="0" layer="51"/>
+<wire x1="1.8288" y1="6.1214" x2="1.3716" y2="6.1214" width="0" layer="51"/>
+<wire x1="1.3716" y1="6.1214" x2="1.3716" y2="5.0546" width="0" layer="51"/>
+<wire x1="0.5842" y1="5.0546" x2="1.016" y2="5.0546" width="0" layer="51"/>
+<wire x1="1.016" y1="5.0546" x2="1.016" y2="6.1214" width="0" layer="51"/>
+<wire x1="1.016" y1="6.1214" x2="0.5842" y2="6.1214" width="0" layer="51"/>
+<wire x1="0.5842" y1="6.1214" x2="0.5842" y2="5.0546" width="0" layer="51"/>
+<wire x1="-0.2286" y1="5.0546" x2="0.2286" y2="5.0546" width="0" layer="51"/>
+<wire x1="0.2286" y1="5.0546" x2="0.2286" y2="6.1214" width="0" layer="51"/>
+<wire x1="0.2286" y1="6.1214" x2="-0.2286" y2="6.1214" width="0" layer="51"/>
+<wire x1="-0.2286" y1="6.1214" x2="-0.2286" y2="5.0546" width="0" layer="51"/>
+<wire x1="-1.016" y1="5.0546" x2="-0.5842" y2="5.0546" width="0" layer="51"/>
+<wire x1="-0.5842" y1="5.0546" x2="-0.5842" y2="6.1214" width="0" layer="51"/>
+<wire x1="-0.5842" y1="6.1214" x2="-1.016" y2="6.1214" width="0" layer="51"/>
+<wire x1="-1.016" y1="6.1214" x2="-1.016" y2="5.0546" width="0" layer="51"/>
+<wire x1="-1.8288" y1="5.0546" x2="-1.3716" y2="5.0546" width="0" layer="51"/>
+<wire x1="-1.3716" y1="5.0546" x2="-1.3716" y2="6.1214" width="0" layer="51"/>
+<wire x1="-1.3716" y1="6.1214" x2="-1.8288" y2="6.1214" width="0" layer="51"/>
+<wire x1="-1.8288" y1="6.1214" x2="-1.8288" y2="5.0546" width="0" layer="51"/>
+<wire x1="-2.6162" y1="5.0546" x2="-2.1844" y2="5.0546" width="0" layer="51"/>
+<wire x1="-2.1844" y1="5.0546" x2="-2.1844" y2="6.1214" width="0" layer="51"/>
+<wire x1="-2.1844" y1="6.1214" x2="-2.6162" y2="6.1214" width="0" layer="51"/>
+<wire x1="-2.6162" y1="6.1214" x2="-2.6162" y2="5.0546" width="0" layer="51"/>
+<wire x1="-3.429" y1="5.0546" x2="-2.9718" y2="5.0546" width="0" layer="51"/>
+<wire x1="-2.9718" y1="5.0546" x2="-2.9718" y2="6.1214" width="0" layer="51"/>
+<wire x1="-2.9718" y1="6.1214" x2="-3.429" y2="6.1214" width="0" layer="51"/>
+<wire x1="-3.429" y1="6.1214" x2="-3.429" y2="5.0546" width="0" layer="51"/>
+<wire x1="-4.2164" y1="5.0546" x2="-3.7846" y2="5.0546" width="0" layer="51"/>
+<wire x1="-3.7846" y1="5.0546" x2="-3.7846" y2="6.1214" width="0" layer="51"/>
+<wire x1="-3.7846" y1="6.1214" x2="-4.2164" y2="6.1214" width="0" layer="51"/>
+<wire x1="-4.2164" y1="6.1214" x2="-4.2164" y2="5.0546" width="0" layer="51"/>
+<wire x1="-5.0546" y1="3.7846" x2="-5.0546" y2="4.2164" width="0" layer="51"/>
+<wire x1="-5.0546" y1="4.2164" x2="-6.1214" y2="4.2164" width="0" layer="51"/>
+<wire x1="-6.1214" y1="4.2164" x2="-6.1214" y2="3.7846" width="0" layer="51"/>
+<wire x1="-6.1214" y1="3.7846" x2="-5.0546" y2="3.7846" width="0" layer="51"/>
+<wire x1="-5.0546" y1="2.9718" x2="-5.0546" y2="3.429" width="0" layer="51"/>
+<wire x1="-5.0546" y1="3.429" x2="-6.1214" y2="3.429" width="0" layer="51"/>
+<wire x1="-6.1214" y1="3.429" x2="-6.1214" y2="2.9718" width="0" layer="51"/>
+<wire x1="-6.1214" y1="2.9718" x2="-5.0546" y2="2.9718" width="0" layer="51"/>
+<wire x1="-5.0546" y1="2.1844" x2="-5.0546" y2="2.6162" width="0" layer="51"/>
+<wire x1="-5.0546" y1="2.6162" x2="-6.1214" y2="2.6162" width="0" layer="51"/>
+<wire x1="-6.1214" y1="2.6162" x2="-6.1214" y2="2.1844" width="0" layer="51"/>
+<wire x1="-6.1214" y1="2.1844" x2="-5.0546" y2="2.1844" width="0" layer="51"/>
+<wire x1="-5.0546" y1="1.3716" x2="-5.0546" y2="1.8288" width="0" layer="51"/>
+<wire x1="-5.0546" y1="1.8288" x2="-6.1214" y2="1.8288" width="0" layer="51"/>
+<wire x1="-6.1214" y1="1.8288" x2="-6.1214" y2="1.3716" width="0" layer="51"/>
+<wire x1="-6.1214" y1="1.3716" x2="-5.0546" y2="1.3716" width="0" layer="51"/>
+<wire x1="-5.0546" y1="0.5842" x2="-5.0546" y2="1.016" width="0" layer="51"/>
+<wire x1="-5.0546" y1="1.016" x2="-6.1214" y2="1.016" width="0" layer="51"/>
+<wire x1="-6.1214" y1="1.016" x2="-6.1214" y2="0.5842" width="0" layer="51"/>
+<wire x1="-6.1214" y1="0.5842" x2="-5.0546" y2="0.5842" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-0.2286" x2="-5.0546" y2="0.2286" width="0" layer="51"/>
+<wire x1="-5.0546" y1="0.2286" x2="-6.1214" y2="0.2286" width="0" layer="51"/>
+<wire x1="-6.1214" y1="0.2286" x2="-6.1214" y2="-0.2286" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-0.2286" x2="-5.0546" y2="-0.2286" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-1.016" x2="-5.0546" y2="-0.5842" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-0.5842" x2="-6.1214" y2="-0.5842" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-0.5842" x2="-6.1214" y2="-1.016" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-1.016" x2="-5.0546" y2="-1.016" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-1.8288" x2="-5.0546" y2="-1.3716" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-1.3716" x2="-6.1214" y2="-1.3716" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-1.3716" x2="-6.1214" y2="-1.8288" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-1.8288" x2="-5.0546" y2="-1.8288" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-2.6162" x2="-5.0546" y2="-2.1844" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-2.1844" x2="-6.1214" y2="-2.1844" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-2.1844" x2="-6.1214" y2="-2.6162" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-2.6162" x2="-5.0546" y2="-2.6162" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-3.429" x2="-5.0546" y2="-2.9718" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-2.9718" x2="-6.1214" y2="-2.9718" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-2.9718" x2="-6.1214" y2="-3.429" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-3.429" x2="-5.0546" y2="-3.429" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-4.2164" x2="-5.0546" y2="-3.7846" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-3.7846" x2="-6.1214" y2="-3.7846" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-3.7846" x2="-6.1214" y2="-4.2164" width="0" layer="51"/>
+<wire x1="-6.1214" y1="-4.2164" x2="-5.0546" y2="-4.2164" width="0" layer="51"/>
+<wire x1="-3.7846" y1="-5.0546" x2="-4.2164" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-4.2164" y1="-5.0546" x2="-4.2164" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-4.2164" y1="-6.1214" x2="-3.7846" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-3.7846" y1="-6.1214" x2="-3.7846" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-2.9718" y1="-5.0546" x2="-3.429" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-3.429" y1="-5.0546" x2="-3.429" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-3.429" y1="-6.1214" x2="-2.9718" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-2.9718" y1="-6.1214" x2="-2.9718" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-2.1844" y1="-5.0546" x2="-2.6162" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-2.6162" y1="-5.0546" x2="-2.6162" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-2.6162" y1="-6.1214" x2="-2.1844" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-2.1844" y1="-6.1214" x2="-2.1844" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-1.3716" y1="-5.0546" x2="-1.8288" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-1.8288" y1="-5.0546" x2="-1.8288" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-1.8288" y1="-6.1214" x2="-1.3716" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-1.3716" y1="-6.1214" x2="-1.3716" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-0.5842" y1="-5.0546" x2="-1.016" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-1.016" y1="-5.0546" x2="-1.016" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-1.016" y1="-6.1214" x2="-0.5842" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-0.5842" y1="-6.1214" x2="-0.5842" y2="-5.0546" width="0" layer="51"/>
+<wire x1="0.2286" y1="-5.0546" x2="-0.2286" y2="-5.0546" width="0" layer="51"/>
+<wire x1="-0.2286" y1="-5.0546" x2="-0.2286" y2="-6.1214" width="0" layer="51"/>
+<wire x1="-0.2286" y1="-6.1214" x2="0.2286" y2="-6.1214" width="0" layer="51"/>
+<wire x1="0.2286" y1="-6.1214" x2="0.2286" y2="-5.0546" width="0" layer="51"/>
+<wire x1="1.016" y1="-5.0546" x2="0.5842" y2="-5.0546" width="0" layer="51"/>
+<wire x1="0.5842" y1="-5.0546" x2="0.5842" y2="-6.1214" width="0" layer="51"/>
+<wire x1="0.5842" y1="-6.1214" x2="1.016" y2="-6.1214" width="0" layer="51"/>
+<wire x1="1.016" y1="-6.1214" x2="1.016" y2="-5.0546" width="0" layer="51"/>
+<wire x1="1.8288" y1="-5.0546" x2="1.3716" y2="-5.0546" width="0" layer="51"/>
+<wire x1="1.3716" y1="-5.0546" x2="1.3716" y2="-6.1214" width="0" layer="51"/>
+<wire x1="1.3716" y1="-6.1214" x2="1.8288" y2="-6.1214" width="0" layer="51"/>
+<wire x1="1.8288" y1="-6.1214" x2="1.8288" y2="-5.0546" width="0" layer="51"/>
+<wire x1="2.6162" y1="-5.0546" x2="2.1844" y2="-5.0546" width="0" layer="51"/>
+<wire x1="2.1844" y1="-5.0546" x2="2.1844" y2="-6.1214" width="0" layer="51"/>
+<wire x1="2.1844" y1="-6.1214" x2="2.6162" y2="-6.1214" width="0" layer="51"/>
+<wire x1="2.6162" y1="-6.1214" x2="2.6162" y2="-5.0546" width="0" layer="51"/>
+<wire x1="3.429" y1="-5.0546" x2="2.9718" y2="-5.0546" width="0" layer="51"/>
+<wire x1="2.9718" y1="-5.0546" x2="2.9718" y2="-6.1214" width="0" layer="51"/>
+<wire x1="2.9718" y1="-6.1214" x2="3.429" y2="-6.1214" width="0" layer="51"/>
+<wire x1="3.429" y1="-6.1214" x2="3.429" y2="-5.0546" width="0" layer="51"/>
+<wire x1="4.2164" y1="-5.0546" x2="3.7846" y2="-5.0546" width="0" layer="51"/>
+<wire x1="3.7846" y1="-5.0546" x2="3.7846" y2="-6.1214" width="0" layer="51"/>
+<wire x1="3.7846" y1="-6.1214" x2="4.2164" y2="-6.1214" width="0" layer="51"/>
+<wire x1="4.2164" y1="-6.1214" x2="4.2164" y2="-5.0546" width="0" layer="51"/>
+<wire x1="5.0546" y1="-3.7846" x2="5.0546" y2="-4.2164" width="0" layer="51"/>
+<wire x1="5.0546" y1="-4.2164" x2="6.1214" y2="-4.2164" width="0" layer="51"/>
+<wire x1="6.1214" y1="-4.2164" x2="6.1214" y2="-3.7846" width="0" layer="51"/>
+<wire x1="6.1214" y1="-3.7846" x2="5.0546" y2="-3.7846" width="0" layer="51"/>
+<wire x1="5.0546" y1="-2.9718" x2="5.0546" y2="-3.429" width="0" layer="51"/>
+<wire x1="5.0546" y1="-3.429" x2="6.1214" y2="-3.429" width="0" layer="51"/>
+<wire x1="6.1214" y1="-3.429" x2="6.1214" y2="-2.9718" width="0" layer="51"/>
+<wire x1="6.1214" y1="-2.9718" x2="5.0546" y2="-2.9718" width="0" layer="51"/>
+<wire x1="5.0546" y1="-2.1844" x2="5.0546" y2="-2.6162" width="0" layer="51"/>
+<wire x1="5.0546" y1="-2.6162" x2="6.1214" y2="-2.6162" width="0" layer="51"/>
+<wire x1="6.1214" y1="-2.6162" x2="6.1214" y2="-2.1844" width="0" layer="51"/>
+<wire x1="6.1214" y1="-2.1844" x2="5.0546" y2="-2.1844" width="0" layer="51"/>
+<wire x1="5.0546" y1="-1.3716" x2="5.0546" y2="-1.8288" width="0" layer="51"/>
+<wire x1="5.0546" y1="-1.8288" x2="6.1214" y2="-1.8288" width="0" layer="51"/>
+<wire x1="6.1214" y1="-1.8288" x2="6.1214" y2="-1.3716" width="0" layer="51"/>
+<wire x1="6.1214" y1="-1.3716" x2="5.0546" y2="-1.3716" width="0" layer="51"/>
+<wire x1="5.0546" y1="-0.5842" x2="5.0546" y2="-1.016" width="0" layer="51"/>
+<wire x1="5.0546" y1="-1.016" x2="6.1214" y2="-1.016" width="0" layer="51"/>
+<wire x1="6.1214" y1="-1.016" x2="6.1214" y2="-0.5842" width="0" layer="51"/>
+<wire x1="6.1214" y1="-0.5842" x2="5.0546" y2="-0.5842" width="0" layer="51"/>
+<wire x1="5.0546" y1="0.2286" x2="5.0546" y2="-0.2286" width="0" layer="51"/>
+<wire x1="5.0546" y1="-0.2286" x2="6.1214" y2="-0.2286" width="0" layer="51"/>
+<wire x1="6.1214" y1="-0.2286" x2="6.1214" y2="0.2286" width="0" layer="51"/>
+<wire x1="6.1214" y1="0.2286" x2="5.0546" y2="0.2286" width="0" layer="51"/>
+<wire x1="5.0546" y1="1.016" x2="5.0546" y2="0.5842" width="0" layer="51"/>
+<wire x1="5.0546" y1="0.5842" x2="6.1214" y2="0.5842" width="0" layer="51"/>
+<wire x1="6.1214" y1="0.5842" x2="6.1214" y2="1.016" width="0" layer="51"/>
+<wire x1="6.1214" y1="1.016" x2="5.0546" y2="1.016" width="0" layer="51"/>
+<wire x1="5.0546" y1="1.8288" x2="5.0546" y2="1.3716" width="0" layer="51"/>
+<wire x1="5.0546" y1="1.3716" x2="6.1214" y2="1.3716" width="0" layer="51"/>
+<wire x1="6.1214" y1="1.3716" x2="6.1214" y2="1.8288" width="0" layer="51"/>
+<wire x1="6.1214" y1="1.8288" x2="5.0546" y2="1.8288" width="0" layer="51"/>
+<wire x1="5.0546" y1="2.6162" x2="5.0546" y2="2.1844" width="0" layer="51"/>
+<wire x1="5.0546" y1="2.1844" x2="6.1214" y2="2.1844" width="0" layer="51"/>
+<wire x1="6.1214" y1="2.1844" x2="6.1214" y2="2.6162" width="0" layer="51"/>
+<wire x1="6.1214" y1="2.6162" x2="5.0546" y2="2.6162" width="0" layer="51"/>
+<wire x1="5.0546" y1="3.429" x2="5.0546" y2="2.9718" width="0" layer="51"/>
+<wire x1="5.0546" y1="2.9718" x2="6.1214" y2="2.9718" width="0" layer="51"/>
+<wire x1="6.1214" y1="2.9718" x2="6.1214" y2="3.429" width="0" layer="51"/>
+<wire x1="6.1214" y1="3.429" x2="5.0546" y2="3.429" width="0" layer="51"/>
+<wire x1="5.0546" y1="4.2164" x2="5.0546" y2="3.7846" width="0" layer="51"/>
+<wire x1="5.0546" y1="3.7846" x2="6.1214" y2="3.7846" width="0" layer="51"/>
+<wire x1="6.1214" y1="3.7846" x2="6.1214" y2="4.2164" width="0" layer="51"/>
+<wire x1="6.1214" y1="4.2164" x2="5.0546" y2="4.2164" width="0" layer="51"/>
+<wire x1="-5.0546" y1="3.7846" x2="-3.7846" y2="5.0546" width="0" layer="51"/>
+<wire x1="-5.0546" y1="-5.0546" x2="5.0546" y2="-5.0546" width="0" layer="51"/>
+<wire x1="5.0546" y1="-5.0546" x2="5.0546" y2="5.0546" width="0" layer="51"/>
+<wire x1="5.0546" y1="5.0546" x2="-5.0546" y2="5.0546" width="0" layer="51"/>
+<wire x1="-5.0546" y1="5.0546" x2="-5.0546" y2="-5.0546" width="0" layer="51"/>
+<text x="-4.17045" y="-10.0955" size="2.08521875" layer="25" ratio="10" rot="SR0">&gt;NAME</text>
+<text x="-3.46611875" y="10.118" size="2.089859375" layer="27" ratio="10" rot="SR0">&gt;VALUE</text>
+<smd name="1" x="-5.7404" y="3.9878" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="2" x="-5.7404" y="3.2004" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="3" x="-5.7404" y="2.3876" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="4" x="-5.7404" y="1.6002" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="5" x="-5.7404" y="0.7874" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="6" x="-5.7404" y="0" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="7" x="-5.7404" y="-0.7874" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="8" x="-5.7404" y="-1.6002" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="9" x="-5.7404" y="-2.3876" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="10" x="-5.7404" y="-3.2004" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="11" x="-5.7404" y="-3.9878" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="12" x="-3.9878" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="13" x="-3.2004" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="14" x="-2.3876" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="15" x="-1.6002" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="16" x="-0.7874" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="17" x="0" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="18" x="0.7874" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="19" x="1.6002" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="20" x="2.3876" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="21" x="3.2004" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="22" x="3.9878" y="-5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="23" x="5.7404" y="-3.9878" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="24" x="5.7404" y="-3.2004" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="25" x="5.7404" y="-2.3876" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="26" x="5.7404" y="-1.6002" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="27" x="5.7404" y="-0.7874" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="28" x="5.7404" y="0" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="29" x="5.7404" y="0.7874" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="30" x="5.7404" y="1.6002" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="31" x="5.7404" y="2.3876" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="32" x="5.7404" y="3.2004" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="33" x="5.7404" y="3.9878" dx="0.508" dy="1.4732" layer="1" rot="R270"/>
+<smd name="34" x="3.9878" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="35" x="3.2004" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="36" x="2.3876" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="37" x="1.6002" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="38" x="0.7874" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="39" x="0" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="40" x="-0.7874" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="41" x="-1.6002" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="42" x="-2.3876" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="43" x="-3.2004" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+<smd name="44" x="-3.9878" y="5.7404" dx="0.508" dy="1.4732" layer="1" rot="R180"/>
+</package>
+</packages>
+<symbols>
+<symbol name="ATMEGA32U4-AUR">
+<wire x1="-12.7" y1="33.02" x2="-12.7" y2="-40.64" width="0.4064" layer="94"/>
+<wire x1="-12.7" y1="-40.64" x2="12.7" y2="-40.64" width="0.4064" layer="94"/>
+<wire x1="12.7" y1="-40.64" x2="12.7" y2="33.02" width="0.4064" layer="94"/>
+<wire x1="12.7" y1="33.02" x2="-12.7" y2="33.02" width="0.4064" layer="94"/>
+<text x="-5.802640625" y="34.5105" size="2.08691875" layer="95" ratio="10" rot="SR0">&gt;NAME</text>
+<text x="-3.63723125" y="-43.6467" size="2.085690625" layer="96" ratio="10" rot="SR0">&gt;VALUE</text>
+<pin name="VCC_2" x="-17.78" y="27.94" length="middle" direction="pwr"/>
+<pin name="VCC" x="-17.78" y="25.4" length="middle" direction="pwr"/>
+<pin name="UVCC" x="-17.78" y="22.86" length="middle" direction="pwr"/>
+<pin name="AVCC_2" x="-17.78" y="20.32" length="middle" direction="pwr"/>
+<pin name="AVCC" x="-17.78" y="17.78" length="middle" direction="pwr"/>
+<pin name="D-" x="-17.78" y="12.7" length="middle" direction="pas"/>
+<pin name="D+" x="-17.78" y="10.16" length="middle" direction="pas"/>
+<pin name="AREF" x="-17.78" y="7.62" length="middle" direction="in"/>
+<pin name="~RESET" x="-17.78" y="5.08" length="middle" direction="in"/>
+<pin name="XTAL1" x="-17.78" y="2.54" length="middle" direction="in"/>
+<pin name="UCAP" x="-17.78" y="0" length="middle" direction="pwr"/>
+<pin name="VBUS" x="-17.78" y="-2.54" length="middle" direction="in"/>
+<pin name="PF0" x="-17.78" y="-7.62" length="middle"/>
+<pin name="PF1" x="-17.78" y="-10.16" length="middle"/>
+<pin name="PF4" x="-17.78" y="-12.7" length="middle"/>
+<pin name="PF5" x="-17.78" y="-15.24" length="middle"/>
+<pin name="PF6" x="-17.78" y="-17.78" length="middle"/>
+<pin name="PF7" x="-17.78" y="-20.32" length="middle"/>
+<pin name="GND_2" x="-17.78" y="-25.4" length="middle" direction="pas"/>
+<pin name="GND_3" x="-17.78" y="-27.94" length="middle" direction="pas"/>
+<pin name="GND_4" x="-17.78" y="-30.48" length="middle" direction="pas"/>
+<pin name="GND" x="-17.78" y="-33.02" length="middle" direction="pas"/>
+<pin name="UGND" x="-17.78" y="-35.56" length="middle" direction="pas"/>
+<pin name="PB0" x="17.78" y="27.94" length="middle" rot="R180"/>
+<pin name="PB1" x="17.78" y="25.4" length="middle" rot="R180"/>
+<pin name="PB2" x="17.78" y="22.86" length="middle" rot="R180"/>
+<pin name="PB3" x="17.78" y="20.32" length="middle" rot="R180"/>
+<pin name="PB4" x="17.78" y="17.78" length="middle" rot="R180"/>
+<pin name="PB5" x="17.78" y="15.24" length="middle" rot="R180"/>
+<pin name="PB6" x="17.78" y="12.7" length="middle" rot="R180"/>
+<pin name="PB7" x="17.78" y="10.16" length="middle" rot="R180"/>
+<pin name="PC6" x="17.78" y="5.08" length="middle" rot="R180"/>
+<pin name="PC7" x="17.78" y="2.54" length="middle" rot="R180"/>
+<pin name="PD0" x="17.78" y="-2.54" length="middle" rot="R180"/>
+<pin name="PD1" x="17.78" y="-5.08" length="middle" rot="R180"/>
+<pin name="PD2" x="17.78" y="-7.62" length="middle" rot="R180"/>
+<pin name="PD3" x="17.78" y="-10.16" length="middle" rot="R180"/>
+<pin name="PD4" x="17.78" y="-12.7" length="middle" rot="R180"/>
+<pin name="PD5" x="17.78" y="-15.24" length="middle" rot="R180"/>
+<pin name="PD6" x="17.78" y="-17.78" length="middle" rot="R180"/>
+<pin name="PD7" x="17.78" y="-20.32" length="middle" rot="R180"/>
+<pin name="PE2" x="17.78" y="-25.4" length="middle" rot="R180"/>
+<pin name="PE6" x="17.78" y="-27.94" length="middle" rot="R180"/>
+<pin name="XTAL2" x="17.78" y="-33.02" length="middle" direction="out" rot="R180"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="ATMEGA32U4-AUR" prefix="U">
+<description>8-bit Microcontroller with ISP Flash and USB Controller</description>
+<gates>
+<gate name="A" symbol="ATMEGA32U4-AUR" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="QFP80P1200X1200X120-44N">
+<connects>
+<connect gate="A" pin="AREF" pad="42"/>
+<connect gate="A" pin="AVCC" pad="44"/>
+<connect gate="A" pin="AVCC_2" pad="24"/>
+<connect gate="A" pin="D+" pad="4"/>
+<connect gate="A" pin="D-" pad="3"/>
+<connect gate="A" pin="GND" pad="43"/>
+<connect gate="A" pin="GND_2" pad="15"/>
+<connect gate="A" pin="GND_3" pad="23"/>
+<connect gate="A" pin="GND_4" pad="35"/>
+<connect gate="A" pin="PB0" pad="8"/>
+<connect gate="A" pin="PB1" pad="9"/>
+<connect gate="A" pin="PB2" pad="10"/>
+<connect gate="A" pin="PB3" pad="11"/>
+<connect gate="A" pin="PB4" pad="28"/>
+<connect gate="A" pin="PB5" pad="29"/>
+<connect gate="A" pin="PB6" pad="30"/>
+<connect gate="A" pin="PB7" pad="12"/>
+<connect gate="A" pin="PC6" pad="31"/>
+<connect gate="A" pin="PC7" pad="32"/>
+<connect gate="A" pin="PD0" pad="18"/>
+<connect gate="A" pin="PD1" pad="19"/>
+<connect gate="A" pin="PD2" pad="20"/>
+<connect gate="A" pin="PD3" pad="21"/>
+<connect gate="A" pin="PD4" pad="25"/>
+<connect gate="A" pin="PD5" pad="22"/>
+<connect gate="A" pin="PD6" pad="26"/>
+<connect gate="A" pin="PD7" pad="27"/>
+<connect gate="A" pin="PE2" pad="33"/>
+<connect gate="A" pin="PE6" pad="1"/>
+<connect gate="A" pin="PF0" pad="41"/>
+<connect gate="A" pin="PF1" pad="40"/>
+<connect gate="A" pin="PF4" pad="39"/>
+<connect gate="A" pin="PF5" pad="38"/>
+<connect gate="A" pin="PF6" pad="37"/>
+<connect gate="A" pin="PF7" pad="36"/>
+<connect gate="A" pin="UCAP" pad="6"/>
+<connect gate="A" pin="UGND" pad="5"/>
+<connect gate="A" pin="UVCC" pad="2"/>
+<connect gate="A" pin="VBUS" pad="7"/>
+<connect gate="A" pin="VCC" pad="34"/>
+<connect gate="A" pin="VCC_2" pad="14"/>
+<connect gate="A" pin="XTAL1" pad="17"/>
+<connect gate="A" pin="XTAL2" pad="16"/>
+<connect gate="A" pin="~RESET" pad="13"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="AVAILABILITY" value="Unavailable"/>
+<attribute name="DESCRIPTION" value=" ATmega Series 16 MHz 32 KB Flash 2.5 KB SRAM 8-Bit Microcontroller - TQFP-44 "/>
+<attribute name="MF" value="Microchip"/>
+<attribute name="MP" value="ATMEGA32U4-AUR"/>
+<attribute name="PACKAGE" value="TQFP-44 Microchip"/>
+<attribute name="PRICE" value="None"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
 </libraries>
 <attributes>
 </attributes>
@@ -10946,11 +11142,6 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="OC_NEWARK" value="unknown"/>
 </part>
 <part name="SW12" library="Keyboard" deviceset="KEYSWITCH-PLAIN" device="-MX-1U">
-<attribute name="MF" value=""/>
-<attribute name="MPN" value=""/>
-<attribute name="OC_NEWARK" value="unknown"/>
-</part>
-<part name="U$1" library="Controller" deviceset="ATMEGA32U4" device="-QFN44">
 <attribute name="MF" value=""/>
 <attribute name="MPN" value=""/>
 <attribute name="OC_NEWARK" value="unknown"/>
@@ -11044,283 +11235,285 @@ In this library the device names are the same as the pin names of the symbols, t
 <part name="D9" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
 <part name="D10" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
 <part name="D11" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="DIODE" device="DO-1N4148" package3d_urn="urn:adsk.eagle:package:6240748/1"/>
+<part name="U1" library="ATMEGA32U4-AUR" deviceset="ATMEGA32U4-AUR" device=""/>
+<part name="SUPPLY9" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="GND" device=""/>
 </parts>
 <sheets>
 <sheet>
 <plain>
 </plain>
 <instances>
-<instance part="USB1" gate="G$1" x="-27.94" y="71.12" smashed="yes" rot="R180">
-<attribute name="NAME" x="-30.48" y="60.96" size="1.778" layer="95" rot="R180" align="bottom-center"/>
-<attribute name="VALUE" x="-38.1" y="71.12" size="1.778" layer="96" rot="R270" align="top-center"/>
-<attribute name="OC_NEWARK" x="-27.94" y="71.12" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="-27.94" y="71.12" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="-27.94" y="71.12" size="1.778" layer="96" display="off"/>
+<instance part="USB1" gate="G$1" x="30.48" y="81.28" smashed="yes" rot="R180">
+<attribute name="NAME" x="27.94" y="71.12" size="1.778" layer="95" rot="R180" align="bottom-center"/>
+<attribute name="VALUE" x="20.32" y="81.28" size="1.778" layer="96" rot="R270" align="top-center"/>
+<attribute name="OC_NEWARK" x="30.48" y="81.28" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="30.48" y="81.28" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="30.48" y="81.28" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="Y1" gate="G$1" x="22.86" y="48.26" smashed="yes">
-<attribute name="NAME" x="20.32" y="50.8" size="1.778" layer="95" font="vector" align="bottom-center"/>
-<attribute name="VALUE" x="20.32" y="53.34" size="1.778" layer="96" font="vector" align="bottom-center"/>
-<attribute name="OC_NEWARK" x="22.86" y="48.26" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="22.86" y="48.26" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="22.86" y="48.26" size="1.778" layer="96" display="off"/>
+<instance part="Y1" gate="G$1" x="104.14" y="33.02" smashed="yes" rot="R270">
+<attribute name="NAME" x="106.68" y="35.56" size="1.778" layer="95" font="vector" rot="R270" align="bottom-center"/>
+<attribute name="VALUE" x="109.22" y="35.56" size="1.778" layer="96" font="vector" rot="R270" align="bottom-center"/>
+<attribute name="OC_NEWARK" x="104.14" y="33.02" size="1.778" layer="96" rot="R270" display="off"/>
+<attribute name="MF" x="104.14" y="33.02" size="1.778" layer="96" rot="R270" display="off"/>
+<attribute name="MPN" x="104.14" y="33.02" size="1.778" layer="96" rot="R270" display="off"/>
 </instance>
-<instance part="SUPPLY1" gate="GND" x="20.32" y="30.48" smashed="yes">
-<attribute name="VALUE" x="18.415" y="27.305" size="1.778" layer="96"/>
+<instance part="SUPPLY1" gate="GND" x="86.36" y="35.56" smashed="yes" rot="R270">
+<attribute name="VALUE" x="83.185" y="37.465" size="1.778" layer="96" rot="R270"/>
 </instance>
-<instance part="SUPPLY3" gate="G$1" x="20.32" y="15.24" smashed="yes">
-<attribute name="VALUE" x="18.415" y="18.415" size="1.778" layer="96"/>
+<instance part="SUPPLY3" gate="G$1" x="12.7" y="50.8" smashed="yes">
+<attribute name="VALUE" x="10.795" y="53.975" size="1.778" layer="96"/>
 </instance>
-<instance part="SUPPLY4" gate="G$1" x="17.78" y="106.68" smashed="yes" rot="R90">
-<attribute name="VALUE" x="14.605" y="104.775" size="1.778" layer="96" rot="R90"/>
+<instance part="SUPPLY4" gate="G$1" x="81.28" y="114.3" smashed="yes" rot="R90">
+<attribute name="VALUE" x="78.105" y="112.395" size="1.778" layer="96" rot="R90"/>
 </instance>
-<instance part="SUPPLY5" gate="GND" x="17.78" y="99.06" smashed="yes" rot="R270">
-<attribute name="VALUE" x="14.605" y="100.965" size="1.778" layer="96" rot="R270"/>
+<instance part="SUPPLY5" gate="GND" x="81.28" y="106.68" smashed="yes" rot="R270">
+<attribute name="VALUE" x="78.105" y="108.585" size="1.778" layer="96" rot="R270"/>
 </instance>
-<instance part="SUPPLY6" gate="GND" x="78.74" y="45.72" smashed="yes" rot="R270">
-<attribute name="VALUE" x="75.565" y="47.625" size="1.778" layer="96" rot="R270"/>
+<instance part="SUPPLY6" gate="GND" x="187.96" y="27.94" smashed="yes">
+<attribute name="VALUE" x="186.055" y="24.765" size="1.778" layer="96"/>
 </instance>
-<instance part="SUPPLY7" gate="GND" x="5.08" y="71.12" smashed="yes">
-<attribute name="VALUE" x="3.175" y="67.945" size="1.778" layer="96"/>
+<instance part="SUPPLY7" gate="GND" x="55.88" y="78.74" smashed="yes">
+<attribute name="VALUE" x="53.975" y="75.565" size="1.778" layer="96"/>
 </instance>
-<instance part="SUPPLY8" gate="G$1" x="5.08" y="86.36" smashed="yes">
-<attribute name="VALUE" x="3.175" y="89.535" size="1.778" layer="96"/>
+<instance part="SUPPLY8" gate="G$1" x="55.88" y="96.52" smashed="yes">
+<attribute name="VALUE" x="53.975" y="99.695" size="1.778" layer="96"/>
 </instance>
-<instance part="SW01" gate="G$1" x="215.9" y="152.4" smashed="yes" rot="R180">
-<attribute name="NAME" x="222.71" y="147.082" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="215.9" y="152.4" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="215.9" y="152.4" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="215.9" y="152.4" size="1.778" layer="96" display="off"/>
+<instance part="SW01" gate="G$1" x="231.14" y="139.7" smashed="yes" rot="R180">
+<attribute name="NAME" x="237.95" y="134.382" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="231.14" y="139.7" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="231.14" y="139.7" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="231.14" y="139.7" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW02" gate="G$1" x="238.76" y="152.4" smashed="yes" rot="R180">
-<attribute name="NAME" x="245.57" y="147.082" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="238.76" y="152.4" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="238.76" y="152.4" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="238.76" y="152.4" size="1.778" layer="96" display="off"/>
+<instance part="SW02" gate="G$1" x="254" y="139.7" smashed="yes" rot="R180">
+<attribute name="NAME" x="260.81" y="134.382" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="254" y="139.7" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="254" y="139.7" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="254" y="139.7" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW03" gate="G$1" x="261.62" y="152.4" smashed="yes" rot="R180">
-<attribute name="NAME" x="268.43" y="147.082" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="261.62" y="152.4" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="261.62" y="152.4" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="261.62" y="152.4" size="1.778" layer="96" display="off"/>
+<instance part="SW03" gate="G$1" x="276.86" y="139.7" smashed="yes" rot="R180">
+<attribute name="NAME" x="283.67" y="134.382" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="276.86" y="139.7" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="276.86" y="139.7" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="276.86" y="139.7" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW04" gate="G$1" x="215.9" y="114.3" smashed="yes" rot="R180">
-<attribute name="NAME" x="222.71" y="108.982" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="215.9" y="114.3" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="215.9" y="114.3" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="215.9" y="114.3" size="1.778" layer="96" display="off"/>
+<instance part="SW04" gate="G$1" x="231.14" y="101.6" smashed="yes" rot="R180">
+<attribute name="NAME" x="237.95" y="96.282" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="231.14" y="101.6" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="231.14" y="101.6" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="231.14" y="101.6" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW05" gate="G$1" x="238.76" y="114.3" smashed="yes" rot="R180">
-<attribute name="NAME" x="245.57" y="108.982" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="238.76" y="114.3" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="238.76" y="114.3" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="238.76" y="114.3" size="1.778" layer="96" display="off"/>
+<instance part="SW05" gate="G$1" x="254" y="101.6" smashed="yes" rot="R180">
+<attribute name="NAME" x="260.81" y="96.282" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="254" y="101.6" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="254" y="101.6" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="254" y="101.6" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW06" gate="G$1" x="261.62" y="114.3" smashed="yes" rot="R180">
-<attribute name="NAME" x="268.43" y="108.982" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="261.62" y="114.3" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="261.62" y="114.3" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="261.62" y="114.3" size="1.778" layer="96" display="off"/>
+<instance part="SW06" gate="G$1" x="276.86" y="101.6" smashed="yes" rot="R180">
+<attribute name="NAME" x="283.67" y="96.282" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="276.86" y="101.6" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="276.86" y="101.6" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="276.86" y="101.6" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW07" gate="G$1" x="215.9" y="76.2" smashed="yes" rot="R180">
-<attribute name="NAME" x="222.71" y="70.882" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="215.9" y="76.2" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="215.9" y="76.2" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="215.9" y="76.2" size="1.778" layer="96" display="off"/>
+<instance part="SW07" gate="G$1" x="231.14" y="63.5" smashed="yes" rot="R180">
+<attribute name="NAME" x="237.95" y="58.182" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="231.14" y="63.5" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="231.14" y="63.5" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="231.14" y="63.5" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW08" gate="G$1" x="238.76" y="76.2" smashed="yes" rot="R180">
-<attribute name="NAME" x="245.57" y="70.882" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="238.76" y="76.2" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="238.76" y="76.2" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="238.76" y="76.2" size="1.778" layer="96" display="off"/>
+<instance part="SW08" gate="G$1" x="254" y="63.5" smashed="yes" rot="R180">
+<attribute name="NAME" x="260.81" y="58.182" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="254" y="63.5" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="254" y="63.5" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="254" y="63.5" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW09" gate="G$1" x="261.62" y="76.2" smashed="yes" rot="R180">
-<attribute name="NAME" x="268.43" y="70.882" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="261.62" y="76.2" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="261.62" y="76.2" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="261.62" y="76.2" size="1.778" layer="96" display="off"/>
+<instance part="SW09" gate="G$1" x="276.86" y="63.5" smashed="yes" rot="R180">
+<attribute name="NAME" x="283.67" y="58.182" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="276.86" y="63.5" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="276.86" y="63.5" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="276.86" y="63.5" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW10" gate="G$1" x="215.9" y="38.1" smashed="yes" rot="R180">
-<attribute name="NAME" x="222.71" y="32.782" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="215.9" y="38.1" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="215.9" y="38.1" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="215.9" y="38.1" size="1.778" layer="96" display="off"/>
+<instance part="SW10" gate="G$1" x="231.14" y="25.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="237.95" y="20.082" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="231.14" y="25.4" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="231.14" y="25.4" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="231.14" y="25.4" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW11" gate="G$1" x="238.76" y="38.1" smashed="yes" rot="R180">
-<attribute name="NAME" x="245.57" y="32.782" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="238.76" y="38.1" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="238.76" y="38.1" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="238.76" y="38.1" size="1.778" layer="96" display="off"/>
+<instance part="SW11" gate="G$1" x="254" y="25.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="260.81" y="20.082" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="254" y="25.4" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="254" y="25.4" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="254" y="25.4" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW12" gate="G$1" x="261.62" y="38.1" smashed="yes" rot="R180">
-<attribute name="NAME" x="268.43" y="32.782" size="1" layer="95" rot="R180"/>
-<attribute name="OC_NEWARK" x="261.62" y="38.1" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="261.62" y="38.1" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="261.62" y="38.1" size="1.778" layer="96" display="off"/>
+<instance part="SW12" gate="G$1" x="276.86" y="25.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="283.67" y="20.082" size="1" layer="95" rot="R180"/>
+<attribute name="OC_NEWARK" x="276.86" y="25.4" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="276.86" y="25.4" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="276.86" y="25.4" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="U$1" gate="G$1" x="127" y="63.5" smashed="yes">
-<attribute name="NAME" x="127" y="106.68" size="1.778" layer="95" font="vector" align="center"/>
-<attribute name="VALUE" x="127" y="22.86" size="1.778" layer="96" font="vector" align="center"/>
-<attribute name="OC_NEWARK" x="127" y="63.5" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="127" y="63.5" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="127" y="63.5" size="1.778" layer="96" display="off"/>
+<instance part="SW00" gate="G$1" x="91.44" y="106.68" smashed="yes">
+<attribute name="NAME" x="91.44" y="104.394" size="1.27" layer="95" align="bottom-center"/>
+<attribute name="OC_NEWARK" x="91.44" y="106.68" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="91.44" y="106.68" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="91.44" y="106.68" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="SW00" gate="G$1" x="27.94" y="99.06" smashed="yes">
-<attribute name="NAME" x="27.94" y="96.774" size="1.27" layer="95" align="bottom-center"/>
-<attribute name="OC_NEWARK" x="27.94" y="99.06" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="27.94" y="99.06" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="27.94" y="99.06" size="1.778" layer="96" display="off"/>
+<instance part="R1" gate="G$1" x="91.44" y="114.3" smashed="yes">
+<attribute name="NAME" x="87.63" y="115.7986" size="1.778" layer="95"/>
+<attribute name="VALUE" x="87.63" y="110.998" size="1.778" layer="96"/>
+<attribute name="OC_NEWARK" x="91.44" y="114.3" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="91.44" y="114.3" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="91.44" y="114.3" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="R1" gate="G$1" x="27.94" y="106.68" smashed="yes">
-<attribute name="NAME" x="24.13" y="108.1786" size="1.778" layer="95"/>
-<attribute name="VALUE" x="24.13" y="103.378" size="1.778" layer="96"/>
-<attribute name="OC_NEWARK" x="27.94" y="106.68" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="27.94" y="106.68" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="27.94" y="106.68" size="1.778" layer="96" display="off"/>
+<instance part="R2" gate="G$1" x="187.96" y="43.18" smashed="yes" rot="R90">
+<attribute name="NAME" x="186.4614" y="39.37" size="1.778" layer="95" rot="R90"/>
+<attribute name="VALUE" x="191.262" y="39.37" size="1.778" layer="96" rot="R90"/>
+<attribute name="OC_NEWARK" x="187.96" y="43.18" size="1.778" layer="96" rot="R90" display="off"/>
+<attribute name="MF" x="187.96" y="43.18" size="1.778" layer="96" rot="R90" display="off"/>
+<attribute name="MPN" x="187.96" y="43.18" size="1.778" layer="96" rot="R90" display="off"/>
 </instance>
-<instance part="R2" gate="G$1" x="88.9" y="45.72" smashed="yes">
-<attribute name="NAME" x="85.09" y="47.2186" size="1.778" layer="95"/>
-<attribute name="VALUE" x="85.09" y="42.418" size="1.778" layer="96"/>
-<attribute name="OC_NEWARK" x="88.9" y="45.72" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="88.9" y="45.72" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="88.9" y="45.72" size="1.778" layer="96" display="off"/>
+<instance part="R4" gate="G$1" x="63.5" y="91.44" smashed="yes">
+<attribute name="NAME" x="59.69" y="92.9386" size="1.778" layer="95"/>
+<attribute name="VALUE" x="59.69" y="88.138" size="1.778" layer="96"/>
+<attribute name="OC_NEWARK" x="63.5" y="91.44" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="63.5" y="91.44" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="63.5" y="91.44" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="R4" gate="G$1" x="17.78" y="81.28" smashed="yes">
-<attribute name="NAME" x="13.97" y="82.7786" size="1.778" layer="95"/>
-<attribute name="VALUE" x="13.97" y="77.978" size="1.778" layer="96"/>
-<attribute name="OC_NEWARK" x="17.78" y="81.28" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="17.78" y="81.28" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="17.78" y="81.28" size="1.778" layer="96" display="off"/>
+<instance part="R3" gate="G$1" x="76.2" y="88.9" smashed="yes">
+<attribute name="NAME" x="72.39" y="90.3986" size="1.778" layer="95"/>
+<attribute name="VALUE" x="72.39" y="85.598" size="1.778" layer="96"/>
+<attribute name="OC_NEWARK" x="76.2" y="88.9" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="76.2" y="88.9" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="76.2" y="88.9" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="R3" gate="G$1" x="33.02" y="78.74" smashed="yes">
-<attribute name="NAME" x="29.21" y="80.2386" size="1.778" layer="95"/>
-<attribute name="VALUE" x="29.21" y="75.438" size="1.778" layer="96"/>
-<attribute name="OC_NEWARK" x="33.02" y="78.74" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="33.02" y="78.74" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="33.02" y="78.74" size="1.778" layer="96" display="off"/>
+<instance part="C1" gate="G$1" x="96.52" y="43.18" smashed="yes">
+<attribute name="NAME" x="91.44" y="43.688" size="1.778" layer="95"/>
+<attribute name="VALUE" x="97.536" y="42.926" size="1.778" layer="96" align="top-left"/>
+<attribute name="OC_NEWARK" x="96.52" y="43.18" size="1.778" layer="96" rot="R270" display="off"/>
+<attribute name="MF" x="96.52" y="43.18" size="1.778" layer="96" rot="R270" display="off"/>
+<attribute name="MPN" x="96.52" y="43.18" size="1.778" layer="96" rot="R270" display="off"/>
 </instance>
-<instance part="C1" gate="G$1" x="12.7" y="40.64" smashed="yes" rot="R90">
-<attribute name="NAME" x="12.192" y="35.56" size="1.778" layer="95" rot="R90"/>
-<attribute name="VALUE" x="12.954" y="41.656" size="1.778" layer="96" rot="R90" align="top-left"/>
-<attribute name="OC_NEWARK" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
+<instance part="C2" gate="G$1" x="96.52" y="27.94" smashed="yes">
+<attribute name="NAME" x="91.44" y="28.448" size="1.778" layer="95"/>
+<attribute name="VALUE" x="97.536" y="27.686" size="1.778" layer="96" align="top-left"/>
+<attribute name="OC_NEWARK" x="96.52" y="27.94" size="1.778" layer="96" rot="R270" display="off"/>
+<attribute name="MF" x="96.52" y="27.94" size="1.778" layer="96" rot="R270" display="off"/>
+<attribute name="MPN" x="96.52" y="27.94" size="1.778" layer="96" rot="R270" display="off"/>
 </instance>
-<instance part="C2" gate="G$1" x="27.94" y="40.64" smashed="yes" rot="R90">
-<attribute name="NAME" x="27.432" y="35.56" size="1.778" layer="95" rot="R90"/>
-<attribute name="VALUE" x="28.194" y="41.656" size="1.778" layer="96" rot="R90" align="top-left"/>
+<instance part="C8" gate="G$1" x="88.9" y="86.36" smashed="yes" rot="R180">
+<attribute name="NAME" x="93.98" y="85.852" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="87.884" y="86.614" size="1.778" layer="96" rot="R180" align="top-left"/>
+<attribute name="OC_NEWARK" x="88.9" y="86.36" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="88.9" y="86.36" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="88.9" y="86.36" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="C4" gate="G$1" x="20.32" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="20.828" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="20.066" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
+<attribute name="OC_NEWARK" x="20.32" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="20.32" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="20.32" y="40.64" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="C5" gate="G$1" x="27.94" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="28.448" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="27.686" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
 <attribute name="OC_NEWARK" x="27.94" y="40.64" size="1.778" layer="96" display="off"/>
 <attribute name="MF" x="27.94" y="40.64" size="1.778" layer="96" display="off"/>
 <attribute name="MPN" x="27.94" y="40.64" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="C8" gate="G$1" x="48.26" y="76.2" smashed="yes" rot="R180">
-<attribute name="NAME" x="53.34" y="75.692" size="1.778" layer="95" rot="R180"/>
-<attribute name="VALUE" x="47.244" y="76.454" size="1.778" layer="96" rot="R180" align="top-left"/>
-<attribute name="OC_NEWARK" x="48.26" y="76.2" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="48.26" y="76.2" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="48.26" y="76.2" size="1.778" layer="96" display="off"/>
+<instance part="C6" gate="G$1" x="35.56" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="36.068" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="35.306" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
+<attribute name="OC_NEWARK" x="35.56" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="35.56" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="35.56" y="40.64" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="C4" gate="G$1" x="27.94" y="5.08" smashed="yes" rot="R270">
-<attribute name="NAME" x="28.448" y="10.16" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="27.686" y="4.064" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="27.94" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="27.94" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="27.94" y="5.08" size="1.778" layer="96" display="off"/>
+<instance part="C7" gate="G$1" x="43.18" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="43.688" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="42.926" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
+<attribute name="OC_NEWARK" x="43.18" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="43.18" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="43.18" y="40.64" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="C5" gate="G$1" x="35.56" y="5.08" smashed="yes" rot="R270">
-<attribute name="NAME" x="36.068" y="10.16" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="35.306" y="4.064" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="35.56" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="35.56" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="35.56" y="5.08" size="1.778" layer="96" display="off"/>
+<instance part="C3" gate="G$1" x="12.7" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="13.208" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="12.446" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
+<attribute name="OC_NEWARK" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="12.7" y="40.64" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="C6" gate="G$1" x="43.18" y="5.08" smashed="yes" rot="R270">
-<attribute name="NAME" x="43.688" y="10.16" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="42.926" y="4.064" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="43.18" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="43.18" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="43.18" y="5.08" size="1.778" layer="96" display="off"/>
+<instance part="F1" gate="G$1" x="12.7" y="81.28" smashed="yes" rot="R90">
+<attribute name="NAME" x="15.24" y="71.12" size="1.778" layer="95" rot="R90"/>
+<attribute name="VALUE" x="7.62" y="93.98" size="1.778" layer="96" rot="R270"/>
+<attribute name="OC_NEWARK" x="12.7" y="81.28" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="12.7" y="81.28" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="12.7" y="81.28" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="C7" gate="G$1" x="50.8" y="5.08" smashed="yes" rot="R270">
-<attribute name="NAME" x="51.308" y="10.16" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="50.546" y="4.064" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="50.8" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="50.8" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="50.8" y="5.08" size="1.778" layer="96" display="off"/>
+<instance part="SUPPLY10" gate="GND" x="12.7" y="63.5" smashed="yes">
+<attribute name="VALUE" x="10.795" y="60.325" size="1.778" layer="96"/>
 </instance>
-<instance part="C3" gate="G$1" x="20.32" y="5.08" smashed="yes" rot="R270">
-<attribute name="NAME" x="20.828" y="10.16" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="20.066" y="4.064" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="20.32" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="20.32" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="20.32" y="5.08" size="1.778" layer="96" display="off"/>
+<instance part="C9" gate="G$1" x="50.8" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="51.308" y="45.72" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="50.546" y="39.624" size="1.778" layer="96" rot="R270" align="top-left"/>
+<attribute name="OC_NEWARK" x="50.8" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MF" x="50.8" y="40.64" size="1.778" layer="96" display="off"/>
+<attribute name="MPN" x="50.8" y="40.64" size="1.778" layer="96" display="off"/>
 </instance>
-<instance part="F1" gate="G$1" x="-45.72" y="71.12" smashed="yes" rot="R90">
-<attribute name="NAME" x="-43.18" y="60.96" size="1.778" layer="95" rot="R90"/>
-<attribute name="VALUE" x="-50.8" y="83.82" size="1.778" layer="96" rot="R270"/>
-<attribute name="OC_NEWARK" x="-45.72" y="71.12" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="-45.72" y="71.12" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="-45.72" y="71.12" size="1.778" layer="96" display="off"/>
+<instance part="SUPPLY2" gate="GND" x="12.7" y="30.48" smashed="yes">
+<attribute name="VALUE" x="10.795" y="27.305" size="1.778" layer="96"/>
 </instance>
-<instance part="SUPPLY10" gate="GND" x="-45.72" y="53.34" smashed="yes">
-<attribute name="VALUE" x="-47.625" y="50.165" size="1.778" layer="96"/>
+<instance part="D12" gate="G$1" x="274.32" y="7.62" smashed="yes" rot="R270">
+<attribute name="NAME" x="276.86" y="10.16" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="270.51" y="10.16" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="C9" gate="G$1" x="58.42" y="5.08" smashed="yes" rot="R270">
-<attribute name="NAME" x="58.928" y="10.16" size="1.778" layer="95" rot="R270"/>
-<attribute name="VALUE" x="58.166" y="4.064" size="1.778" layer="96" rot="R270" align="top-left"/>
-<attribute name="OC_NEWARK" x="58.42" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MF" x="58.42" y="5.08" size="1.778" layer="96" display="off"/>
-<attribute name="MPN" x="58.42" y="5.08" size="1.778" layer="96" display="off"/>
+<instance part="D1" gate="G$1" x="228.6" y="121.92" smashed="yes" rot="R270">
+<attribute name="NAME" x="231.14" y="124.46" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="224.79" y="124.46" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="SUPPLY2" gate="GND" x="20.32" y="-5.08" smashed="yes">
-<attribute name="VALUE" x="18.415" y="-8.255" size="1.778" layer="96"/>
+<instance part="D2" gate="G$1" x="251.46" y="121.92" smashed="yes" rot="R270">
+<attribute name="NAME" x="254" y="124.46" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="247.65" y="124.46" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="D12" gate="G$1" x="259.08" y="20.32" smashed="yes" rot="R270">
-<attribute name="NAME" x="261.62" y="22.86" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="255.27" y="22.86" size="1.27" layer="96" rot="R270"/>
+<instance part="D3" gate="G$1" x="274.32" y="121.92" smashed="yes" rot="R270">
+<attribute name="NAME" x="276.86" y="124.46" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="270.51" y="124.46" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="D1" gate="G$1" x="213.36" y="134.62" smashed="yes" rot="R270">
-<attribute name="NAME" x="215.9" y="137.16" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="209.55" y="137.16" size="1.27" layer="96" rot="R270"/>
+<instance part="D4" gate="G$1" x="228.6" y="83.82" smashed="yes" rot="R270">
+<attribute name="NAME" x="231.14" y="86.36" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="224.79" y="86.36" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="D2" gate="G$1" x="236.22" y="134.62" smashed="yes" rot="R270">
-<attribute name="NAME" x="238.76" y="137.16" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="232.41" y="137.16" size="1.27" layer="96" rot="R270"/>
+<instance part="D5" gate="G$1" x="251.46" y="83.82" smashed="yes" rot="R270">
+<attribute name="NAME" x="254" y="86.36" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="247.65" y="86.36" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="D3" gate="G$1" x="259.08" y="134.62" smashed="yes" rot="R270">
-<attribute name="NAME" x="261.62" y="137.16" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="255.27" y="137.16" size="1.27" layer="96" rot="R270"/>
+<instance part="D6" gate="G$1" x="274.32" y="83.82" smashed="yes" rot="R270">
+<attribute name="NAME" x="276.86" y="86.36" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="270.51" y="86.36" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="D4" gate="G$1" x="213.36" y="96.52" smashed="yes" rot="R270">
-<attribute name="NAME" x="215.9" y="99.06" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="209.55" y="99.06" size="1.27" layer="96" rot="R270"/>
+<instance part="D7" gate="G$1" x="228.6" y="45.72" smashed="yes" rot="R270">
+<attribute name="NAME" x="231.14" y="48.26" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="224.79" y="48.26" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="D5" gate="G$1" x="236.22" y="96.52" smashed="yes" rot="R270">
-<attribute name="NAME" x="238.76" y="99.06" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="232.41" y="99.06" size="1.27" layer="96" rot="R270"/>
+<instance part="D8" gate="G$1" x="251.46" y="45.72" smashed="yes" rot="R270">
+<attribute name="NAME" x="254" y="48.26" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="247.65" y="48.26" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="D6" gate="G$1" x="259.08" y="96.52" smashed="yes" rot="R270">
-<attribute name="NAME" x="261.62" y="99.06" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="255.27" y="99.06" size="1.27" layer="96" rot="R270"/>
+<instance part="D9" gate="G$1" x="274.32" y="45.72" smashed="yes" rot="R270">
+<attribute name="NAME" x="276.86" y="48.26" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="270.51" y="48.26" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="D7" gate="G$1" x="213.36" y="58.42" smashed="yes" rot="R270">
-<attribute name="NAME" x="215.9" y="60.96" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="209.55" y="60.96" size="1.27" layer="96" rot="R270"/>
+<instance part="D10" gate="G$1" x="228.6" y="7.62" smashed="yes" rot="R270">
+<attribute name="NAME" x="231.14" y="10.16" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="224.79" y="10.16" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="D8" gate="G$1" x="236.22" y="58.42" smashed="yes" rot="R270">
-<attribute name="NAME" x="238.76" y="60.96" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="232.41" y="60.96" size="1.27" layer="96" rot="R270"/>
+<instance part="D11" gate="G$1" x="251.46" y="7.62" smashed="yes" rot="R270">
+<attribute name="NAME" x="254" y="10.16" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="247.65" y="10.16" size="1.27" layer="96" rot="R270"/>
 </instance>
-<instance part="D9" gate="G$1" x="259.08" y="58.42" smashed="yes" rot="R270">
-<attribute name="NAME" x="261.62" y="60.96" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="255.27" y="60.96" size="1.27" layer="96" rot="R270"/>
+<instance part="U1" gate="A" x="152.4" y="76.2" smashed="yes">
+<attribute name="NAME" x="146.597359375" y="110.7105" size="2.08691875" layer="95" ratio="10" rot="SR0"/>
+<attribute name="VALUE" x="148.76276875" y="32.5533" size="2.085690625" layer="96" ratio="10" rot="SR0"/>
 </instance>
-<instance part="D10" gate="G$1" x="213.36" y="20.32" smashed="yes" rot="R270">
-<attribute name="NAME" x="215.9" y="22.86" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="209.55" y="22.86" size="1.27" layer="96" rot="R270"/>
-</instance>
-<instance part="D11" gate="G$1" x="236.22" y="20.32" smashed="yes" rot="R270">
-<attribute name="NAME" x="238.76" y="22.86" size="1.27" layer="95" rot="R270"/>
-<attribute name="VALUE" x="232.41" y="22.86" size="1.27" layer="96" rot="R270"/>
+<instance part="SUPPLY9" gate="GND" x="116.84" y="33.02" smashed="yes">
+<attribute name="VALUE" x="114.935" y="29.845" size="1.778" layer="96"/>
 </instance>
 </instances>
 <busses>
@@ -11328,376 +11521,377 @@ In this library the device names are the same as the pin names of the symbols, t
 <nets>
 <net name="N$1" class="0">
 <segment>
-<pinref part="U$1" gate="G$1" pin="XTAL2"/>
-<wire x1="96.52" y1="58.42" x2="27.94" y2="58.42" width="0.1524" layer="91"/>
 <pinref part="Y1" gate="G$1" pin="2"/>
-<wire x1="25.4" y1="48.26" x2="27.94" y2="48.26" width="0.1524" layer="91"/>
-<junction x="27.94" y="48.26"/>
-<wire x1="27.94" y1="45.72" x2="27.94" y2="48.26" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="58.42" x2="27.94" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="104.14" y1="30.48" x2="104.14" y2="27.94" width="0.1524" layer="91"/>
+<junction x="104.14" y="27.94"/>
+<wire x1="101.6" y1="27.94" x2="104.14" y2="27.94" width="0.1524" layer="91"/>
 <pinref part="C2" gate="G$1" pin="2"/>
+<pinref part="U1" gate="A" pin="XTAL2"/>
+<wire x1="170.18" y1="43.18" x2="177.8" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="177.8" y1="43.18" x2="177.8" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="177.8" y1="27.94" x2="104.14" y2="27.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$2" class="0">
 <segment>
-<wire x1="96.52" y1="63.5" x2="12.7" y2="63.5" width="0.1524" layer="91"/>
-<wire x1="12.7" y1="63.5" x2="12.7" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="104.14" y1="78.74" x2="104.14" y2="43.18" width="0.1524" layer="91"/>
 <pinref part="Y1" gate="G$1" pin="1"/>
-<wire x1="12.7" y1="48.26" x2="12.7" y2="45.72" width="0.1524" layer="91"/>
-<wire x1="15.24" y1="48.26" x2="12.7" y2="48.26" width="0.1524" layer="91"/>
-<junction x="12.7" y="48.26"/>
-<pinref part="U$1" gate="G$1" pin="XTAL1"/>
+<wire x1="104.14" y1="43.18" x2="101.6" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="104.14" y1="40.64" x2="104.14" y2="43.18" width="0.1524" layer="91"/>
+<junction x="104.14" y="43.18"/>
 <pinref part="C1" gate="G$1" pin="2"/>
+<pinref part="U1" gate="A" pin="XTAL1"/>
+<wire x1="104.14" y1="78.74" x2="134.62" y2="78.74" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="VCC" class="0">
 <segment>
-<wire x1="50.8" y1="10.16" x2="43.18" y2="10.16" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="45.72" x2="35.56" y2="45.72" width="0.1524" layer="91"/>
 <pinref part="SUPPLY3" gate="G$1" pin="VCC"/>
-<wire x1="43.18" y1="10.16" x2="35.56" y2="10.16" width="0.1524" layer="91"/>
-<wire x1="35.56" y1="10.16" x2="27.94" y2="10.16" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="10.16" x2="20.32" y2="10.16" width="0.1524" layer="91"/>
-<wire x1="20.32" y1="12.7" x2="20.32" y2="10.16" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="45.72" x2="27.94" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="45.72" x2="20.32" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="20.32" y1="45.72" x2="12.7" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="48.26" x2="12.7" y2="45.72" width="0.1524" layer="91"/>
 <pinref part="C3" gate="G$1" pin="1"/>
-<junction x="20.32" y="10.16"/>
+<junction x="12.7" y="45.72"/>
 <pinref part="C4" gate="G$1" pin="1"/>
-<junction x="27.94" y="10.16"/>
+<junction x="20.32" y="45.72"/>
 <pinref part="C5" gate="G$1" pin="1"/>
-<junction x="35.56" y="10.16"/>
+<junction x="27.94" y="45.72"/>
 <pinref part="C6" gate="G$1" pin="1"/>
-<junction x="43.18" y="10.16"/>
+<junction x="35.56" y="45.72"/>
 <pinref part="C7" gate="G$1" pin="1"/>
 <pinref part="C9" gate="G$1" pin="1"/>
-<wire x1="58.42" y1="10.16" x2="50.8" y2="10.16" width="0.1524" layer="91"/>
-<junction x="50.8" y="10.16"/>
+<wire x1="50.8" y1="45.72" x2="43.18" y2="45.72" width="0.1524" layer="91"/>
+<junction x="43.18" y="45.72"/>
 </segment>
 <segment>
 <pinref part="SUPPLY4" gate="G$1" pin="VCC"/>
-<wire x1="22.86" y1="106.68" x2="20.32" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="86.36" y1="114.3" x2="83.82" y2="114.3" width="0.1524" layer="91"/>
 <pinref part="R1" gate="G$1" pin="1"/>
 </segment>
 <segment>
 <pinref part="USB1" gate="G$1" pin="VCC"/>
-<wire x1="-12.7" y1="66.04" x2="-22.86" y2="66.04" width="0.1524" layer="91"/>
-<wire x1="83.82" y1="83.82" x2="5.08" y2="83.82" width="0.1524" layer="91"/>
-<wire x1="5.08" y1="83.82" x2="-12.7" y2="83.82" width="0.1524" layer="91"/>
-<wire x1="-12.7" y1="83.82" x2="-12.7" y2="66.04" width="0.1524" layer="91"/>
+<wire x1="45.72" y1="76.2" x2="35.56" y2="76.2" width="0.1524" layer="91"/>
+<wire x1="101.6" y1="93.98" x2="55.88" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="55.88" y1="93.98" x2="45.72" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="45.72" y1="93.98" x2="45.72" y2="76.2" width="0.1524" layer="91"/>
 <pinref part="SUPPLY8" gate="G$1" pin="VCC"/>
-<junction x="5.08" y="83.82"/>
-<pinref part="U$1" gate="G$1" pin="VCC@34"/>
-<wire x1="96.52" y1="99.06" x2="93.98" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="93.98" y1="99.06" x2="93.98" y2="101.6" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="VCC@14"/>
-<wire x1="93.98" y1="101.6" x2="96.52" y2="101.6" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="AVCC@24"/>
-<wire x1="96.52" y1="96.52" x2="93.98" y2="96.52" width="0.1524" layer="91"/>
-<wire x1="93.98" y1="96.52" x2="93.98" y2="99.06" width="0.1524" layer="91"/>
-<junction x="93.98" y="99.06"/>
-<pinref part="U$1" gate="G$1" pin="AVCC@44"/>
-<wire x1="96.52" y1="93.98" x2="93.98" y2="93.98" width="0.1524" layer="91"/>
-<wire x1="93.98" y1="93.98" x2="93.98" y2="96.52" width="0.1524" layer="91"/>
-<junction x="93.98" y="96.52"/>
-<pinref part="U$1" gate="G$1" pin="VBUS"/>
-<wire x1="96.52" y1="88.9" x2="93.98" y2="88.9" width="0.1524" layer="91"/>
-<wire x1="93.98" y1="88.9" x2="93.98" y2="93.98" width="0.1524" layer="91"/>
-<junction x="93.98" y="93.98"/>
-<pinref part="U$1" gate="G$1" pin="UVCC"/>
-<wire x1="96.52" y1="86.36" x2="93.98" y2="86.36" width="0.1524" layer="91"/>
-<wire x1="93.98" y1="86.36" x2="93.98" y2="88.9" width="0.1524" layer="91"/>
-<junction x="93.98" y="88.9"/>
-<wire x1="93.98" y1="86.36" x2="83.82" y2="86.36" width="0.1524" layer="91"/>
-<wire x1="83.82" y1="86.36" x2="83.82" y2="83.82" width="0.1524" layer="91"/>
-<junction x="93.98" y="86.36"/>
+<junction x="55.88" y="93.98"/>
+<wire x1="101.6" y1="96.52" x2="101.6" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="101.6" y1="96.52" x2="127" y2="96.52" width="0.1524" layer="91"/>
+<wire x1="127" y1="96.52" x2="127" y2="99.06" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="VCC_2"/>
+<wire x1="127" y1="99.06" x2="127" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="127" y1="101.6" x2="127" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="127" y1="104.14" x2="134.62" y2="104.14" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="VCC"/>
+<wire x1="134.62" y1="101.6" x2="127" y2="101.6" width="0.1524" layer="91"/>
+<junction x="127" y="101.6"/>
+<pinref part="U1" gate="A" pin="AVCC_2"/>
+<wire x1="134.62" y1="96.52" x2="127" y2="96.52" width="0.1524" layer="91"/>
+<junction x="127" y="96.52"/>
+<pinref part="U1" gate="A" pin="AVCC"/>
+<wire x1="134.62" y1="93.98" x2="127" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="127" y1="93.98" x2="127" y2="96.52" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="VBUS"/>
+<wire x1="134.62" y1="73.66" x2="127" y2="73.66" width="0.1524" layer="91"/>
+<wire x1="127" y1="73.66" x2="127" y2="93.98" width="0.1524" layer="91"/>
+<junction x="127" y="93.98"/>
+<pinref part="U1" gate="A" pin="UVCC"/>
+<wire x1="134.62" y1="99.06" x2="127" y2="99.06" width="0.1524" layer="91"/>
+<junction x="127" y="99.06"/>
 </segment>
 </net>
 <net name="N$3" class="0">
 <segment>
-<wire x1="33.02" y1="106.68" x2="35.56" y2="106.68" width="0.1524" layer="91"/>
-<wire x1="35.56" y1="106.68" x2="35.56" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="35.56" y1="99.06" x2="33.02" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="35.56" y1="99.06" x2="58.42" y2="99.06" width="0.1524" layer="91"/>
-<junction x="35.56" y="99.06"/>
-<pinref part="U$1" gate="G$1" pin="!RESET"/>
-<wire x1="96.52" y1="50.8" x2="58.42" y2="50.8" width="0.1524" layer="91"/>
-<wire x1="58.42" y1="99.06" x2="58.42" y2="50.8" width="0.1524" layer="91"/>
 <pinref part="SW00" gate="G$1" pin="2"/>
+<wire x1="96.52" y1="106.68" x2="99.06" y2="106.68" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="~RESET"/>
+<wire x1="99.06" y1="106.68" x2="104.14" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="104.14" y1="106.68" x2="104.14" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="104.14" y1="81.28" x2="134.62" y2="81.28" width="0.1524" layer="91"/>
 <pinref part="R1" gate="G$1" pin="2"/>
+<wire x1="96.52" y1="114.3" x2="99.06" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="99.06" y1="114.3" x2="99.06" y2="106.68" width="0.1524" layer="91"/>
+<junction x="99.06" y="106.68"/>
 </segment>
 </net>
 <net name="UCAP" class="0">
 <segment>
-<wire x1="86.36" y1="76.2" x2="53.34" y2="76.2" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="UCAP"/>
-<wire x1="96.52" y1="83.82" x2="86.36" y2="83.82" width="0.1524" layer="91"/>
-<wire x1="86.36" y1="83.82" x2="86.36" y2="76.2" width="0.1524" layer="91"/>
 <pinref part="C8" gate="G$1" pin="1"/>
+<pinref part="U1" gate="A" pin="UCAP"/>
+<wire x1="96.52" y1="76.2" x2="134.62" y2="76.2" width="0.1524" layer="91"/>
+<wire x1="93.98" y1="86.36" x2="96.52" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="86.36" x2="96.52" y2="76.2" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$5" class="0">
 <segment>
 <pinref part="USB1" gate="G$1" pin="D_P"/>
-<wire x1="-22.86" y1="71.12" x2="-10.16" y2="71.12" width="0.1524" layer="91"/>
-<wire x1="-10.16" y1="71.12" x2="-10.16" y2="81.28" width="0.1524" layer="91"/>
-<wire x1="-10.16" y1="81.28" x2="12.7" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="81.28" x2="48.26" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="81.28" x2="48.26" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="91.44" x2="58.42" y2="91.44" width="0.1524" layer="91"/>
 <pinref part="R4" gate="G$1" pin="1"/>
 </segment>
 </net>
 <net name="N$6" class="0">
 <segment>
-<wire x1="22.86" y1="81.28" x2="83.82" y2="81.28" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="D-"/>
-<wire x1="96.52" y1="73.66" x2="83.82" y2="73.66" width="0.1524" layer="91"/>
-<wire x1="83.82" y1="73.66" x2="83.82" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="91.44" x2="101.6" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="101.6" y1="88.9" x2="101.6" y2="91.44" width="0.1524" layer="91"/>
 <pinref part="R4" gate="G$1" pin="2"/>
+<wire x1="101.6" y1="88.9" x2="134.62" y2="88.9" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="D-"/>
 </segment>
 </net>
 <net name="N$7" class="0">
 <segment>
 <pinref part="USB1" gate="G$1" pin="D_M"/>
-<wire x1="-22.86" y1="68.58" x2="-7.62" y2="68.58" width="0.1524" layer="91"/>
-<wire x1="-7.62" y1="68.58" x2="-7.62" y2="78.74" width="0.1524" layer="91"/>
-<wire x1="-7.62" y1="78.74" x2="27.94" y2="78.74" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="78.74" x2="50.8" y2="78.74" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="78.74" x2="50.8" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="88.9" x2="71.12" y2="88.9" width="0.1524" layer="91"/>
 <pinref part="R3" gate="G$1" pin="1"/>
 </segment>
 </net>
 <net name="N$8" class="0">
 <segment>
-<wire x1="38.1" y1="78.74" x2="81.28" y2="78.74" width="0.1524" layer="91"/>
-<wire x1="81.28" y1="78.74" x2="81.28" y2="71.12" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="D+"/>
-<wire x1="81.28" y1="71.12" x2="96.52" y2="71.12" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="88.9" x2="99.06" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="99.06" y1="88.9" x2="99.06" y2="86.36" width="0.1524" layer="91"/>
 <pinref part="R3" gate="G$1" pin="2"/>
+<pinref part="U1" gate="A" pin="D+"/>
+<wire x1="134.62" y1="86.36" x2="99.06" y2="86.36" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$9" class="0">
 <segment>
 <pinref part="SW01" gate="G$1" pin="P1"/>
 <pinref part="D1" gate="G$1" pin="A"/>
-<wire x1="213.36" y1="142.24" x2="213.36" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="228.6" y1="129.54" x2="228.6" y2="124.46" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$10" class="0">
 <segment>
 <pinref part="SW01" gate="G$1" pin="P0"/>
-<wire x1="226.06" y1="149.86" x2="228.6" y2="149.86" width="0.1524" layer="91"/>
-<wire x1="228.6" y1="149.86" x2="228.6" y2="172.72" width="0.1524" layer="91"/>
+<wire x1="241.3" y1="137.16" x2="243.84" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="243.84" y1="137.16" x2="243.84" y2="160.02" width="0.1524" layer="91"/>
 <pinref part="SW04" gate="G$1" pin="P0"/>
-<wire x1="226.06" y1="111.76" x2="228.6" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="228.6" y1="149.86" x2="228.6" y2="111.76" width="0.1524" layer="91"/>
-<junction x="228.6" y="149.86"/>
+<wire x1="241.3" y1="99.06" x2="243.84" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="243.84" y1="137.16" x2="243.84" y2="99.06" width="0.1524" layer="91"/>
+<junction x="243.84" y="137.16"/>
 <pinref part="SW07" gate="G$1" pin="P0"/>
-<wire x1="226.06" y1="73.66" x2="228.6" y2="73.66" width="0.1524" layer="91"/>
-<wire x1="228.6" y1="111.76" x2="228.6" y2="73.66" width="0.1524" layer="91"/>
-<junction x="228.6" y="111.76"/>
+<wire x1="241.3" y1="60.96" x2="243.84" y2="60.96" width="0.1524" layer="91"/>
+<wire x1="243.84" y1="99.06" x2="243.84" y2="60.96" width="0.1524" layer="91"/>
+<junction x="243.84" y="99.06"/>
 <pinref part="SW10" gate="G$1" pin="P0"/>
-<wire x1="226.06" y1="35.56" x2="228.6" y2="35.56" width="0.1524" layer="91"/>
-<wire x1="228.6" y1="73.66" x2="228.6" y2="35.56" width="0.1524" layer="91"/>
-<junction x="228.6" y="73.66"/>
-<wire x1="195.58" y1="172.72" x2="228.6" y2="172.72" width="0.1524" layer="91"/>
-<wire x1="195.58" y1="55.88" x2="195.58" y2="172.72" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="PB5(PCINT5/OC1A/ADC12/!OC4B)"/>
-<wire x1="154.94" y1="55.88" x2="195.58" y2="55.88" width="0.1524" layer="91"/>
+<wire x1="241.3" y1="22.86" x2="243.84" y2="22.86" width="0.1524" layer="91"/>
+<wire x1="243.84" y1="60.96" x2="243.84" y2="22.86" width="0.1524" layer="91"/>
+<junction x="243.84" y="60.96"/>
+<wire x1="210.82" y1="160.02" x2="243.84" y2="160.02" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PB5"/>
+<wire x1="210.82" y1="91.44" x2="210.82" y2="160.02" width="0.1524" layer="91"/>
+<wire x1="170.18" y1="91.44" x2="210.82" y2="91.44" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$12" class="0">
 <segment>
 <pinref part="SW02" gate="G$1" pin="P1"/>
 <pinref part="D2" gate="G$1" pin="A"/>
-<wire x1="236.22" y1="137.16" x2="236.22" y2="142.24" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="124.46" x2="251.46" y2="129.54" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$14" class="0">
 <segment>
-<wire x1="236.22" y1="127" x2="259.08" y2="127" width="0.1524" layer="91"/>
-<wire x1="236.22" y1="127" x2="213.36" y2="127" width="0.1524" layer="91"/>
-<junction x="213.36" y="127"/>
-<wire x1="213.36" y1="127" x2="187.96" y2="127" width="0.1524" layer="91"/>
-<junction x="236.22" y="127"/>
-<wire x1="187.96" y1="127" x2="187.96" y2="68.58" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="PD4(ICP1/ADC8)"/>
-<wire x1="187.96" y1="68.58" x2="154.94" y2="68.58" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="114.3" x2="274.32" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="114.3" x2="228.6" y2="114.3" width="0.1524" layer="91"/>
+<junction x="228.6" y="114.3"/>
+<wire x1="228.6" y1="114.3" x2="203.2" y2="114.3" width="0.1524" layer="91"/>
+<junction x="251.46" y="114.3"/>
+<wire x1="203.2" y1="114.3" x2="203.2" y2="63.5" width="0.1524" layer="91"/>
 <pinref part="D1" gate="G$1" pin="C"/>
-<wire x1="213.36" y1="132.08" x2="213.36" y2="127" width="0.1524" layer="91"/>
+<wire x1="228.6" y1="119.38" x2="228.6" y2="114.3" width="0.1524" layer="91"/>
 <pinref part="D2" gate="G$1" pin="C"/>
-<wire x1="236.22" y1="132.08" x2="236.22" y2="127" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="119.38" x2="251.46" y2="114.3" width="0.1524" layer="91"/>
 <pinref part="D3" gate="G$1" pin="C"/>
-<wire x1="259.08" y1="132.08" x2="259.08" y2="127" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="119.38" x2="274.32" y2="114.3" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PD4"/>
+<wire x1="170.18" y1="63.5" x2="203.2" y2="63.5" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$15" class="0">
 <segment>
 <pinref part="SW03" gate="G$1" pin="P1"/>
-<wire x1="259.08" y1="142.24" x2="259.08" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="129.54" x2="274.32" y2="124.46" width="0.1524" layer="91"/>
 <pinref part="D3" gate="G$1" pin="A"/>
 </segment>
 </net>
 <net name="N$16" class="0">
 <segment>
 <pinref part="SW03" gate="G$1" pin="P0"/>
-<wire x1="271.78" y1="149.86" x2="274.32" y2="149.86" width="0.1524" layer="91"/>
-<wire x1="274.32" y1="149.86" x2="274.32" y2="177.8" width="0.1524" layer="91"/>
+<wire x1="287.02" y1="137.16" x2="289.56" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="289.56" y1="137.16" x2="289.56" y2="165.1" width="0.1524" layer="91"/>
 <pinref part="SW06" gate="G$1" pin="P0"/>
-<wire x1="271.78" y1="111.76" x2="274.32" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="274.32" y1="149.86" x2="274.32" y2="111.76" width="0.1524" layer="91"/>
-<junction x="274.32" y="149.86"/>
+<wire x1="287.02" y1="99.06" x2="289.56" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="289.56" y1="137.16" x2="289.56" y2="99.06" width="0.1524" layer="91"/>
+<junction x="289.56" y="137.16"/>
 <pinref part="SW09" gate="G$1" pin="P0"/>
-<wire x1="271.78" y1="73.66" x2="274.32" y2="73.66" width="0.1524" layer="91"/>
-<wire x1="274.32" y1="111.76" x2="274.32" y2="73.66" width="0.1524" layer="91"/>
-<junction x="274.32" y="111.76"/>
+<wire x1="287.02" y1="60.96" x2="289.56" y2="60.96" width="0.1524" layer="91"/>
+<wire x1="289.56" y1="99.06" x2="289.56" y2="60.96" width="0.1524" layer="91"/>
+<junction x="289.56" y="99.06"/>
 <pinref part="SW12" gate="G$1" pin="P0"/>
-<wire x1="271.78" y1="35.56" x2="274.32" y2="35.56" width="0.1524" layer="91"/>
-<wire x1="274.32" y1="73.66" x2="274.32" y2="35.56" width="0.1524" layer="91"/>
-<junction x="274.32" y="73.66"/>
-<wire x1="190.5" y1="177.8" x2="274.32" y2="177.8" width="0.1524" layer="91"/>
-<wire x1="190.5" y1="177.8" x2="190.5" y2="66.04" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="PC6(OC3A/!OC4A)"/>
-<wire x1="190.5" y1="66.04" x2="154.94" y2="66.04" width="0.1524" layer="91"/>
+<wire x1="287.02" y1="22.86" x2="289.56" y2="22.86" width="0.1524" layer="91"/>
+<wire x1="289.56" y1="60.96" x2="289.56" y2="22.86" width="0.1524" layer="91"/>
+<junction x="289.56" y="60.96"/>
+<wire x1="205.74" y1="165.1" x2="289.56" y2="165.1" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PC6"/>
+<wire x1="170.18" y1="81.28" x2="205.74" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="205.74" y1="81.28" x2="205.74" y2="165.1" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$18" class="0">
 <segment>
 <pinref part="SW04" gate="G$1" pin="P1"/>
 <pinref part="D4" gate="G$1" pin="A"/>
-<wire x1="213.36" y1="104.14" x2="213.36" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="228.6" y1="91.44" x2="228.6" y2="86.36" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$21" class="0">
 <segment>
 <pinref part="SW05" gate="G$1" pin="P1"/>
 <pinref part="D5" gate="G$1" pin="A"/>
-<wire x1="236.22" y1="104.14" x2="236.22" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="91.44" x2="251.46" y2="86.36" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$24" class="0">
 <segment>
 <pinref part="SW06" gate="G$1" pin="P1"/>
 <pinref part="D6" gate="G$1" pin="A"/>
-<wire x1="259.08" y1="104.14" x2="259.08" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="91.44" x2="274.32" y2="86.36" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$26" class="0">
 <segment>
-<wire x1="259.08" y1="88.9" x2="236.22" y2="88.9" width="0.1524" layer="91"/>
-<junction x="236.22" y="88.9"/>
-<wire x1="236.22" y1="88.9" x2="213.36" y2="88.9" width="0.1524" layer="91"/>
-<junction x="213.36" y="88.9"/>
-<wire x1="213.36" y1="88.9" x2="185.42" y2="88.9" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="PD6(T1/ADC9/!OC4D)"/>
-<wire x1="185.42" y1="88.9" x2="185.42" y2="48.26" width="0.1524" layer="91"/>
-<wire x1="185.42" y1="48.26" x2="154.94" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="76.2" x2="251.46" y2="76.2" width="0.1524" layer="91"/>
+<junction x="251.46" y="76.2"/>
+<wire x1="251.46" y1="76.2" x2="228.6" y2="76.2" width="0.1524" layer="91"/>
+<junction x="228.6" y="76.2"/>
+<wire x1="228.6" y1="76.2" x2="205.74" y2="76.2" width="0.1524" layer="91"/>
 <pinref part="D4" gate="G$1" pin="C"/>
-<wire x1="213.36" y1="93.98" x2="213.36" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="228.6" y1="81.28" x2="228.6" y2="76.2" width="0.1524" layer="91"/>
 <pinref part="D5" gate="G$1" pin="C"/>
-<wire x1="236.22" y1="93.98" x2="236.22" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="81.28" x2="251.46" y2="76.2" width="0.1524" layer="91"/>
 <pinref part="D6" gate="G$1" pin="C"/>
-<wire x1="259.08" y1="93.98" x2="259.08" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="81.28" x2="274.32" y2="76.2" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PD6"/>
+<wire x1="170.18" y1="58.42" x2="205.74" y2="58.42" width="0.1524" layer="91"/>
+<wire x1="205.74" y1="58.42" x2="205.74" y2="76.2" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$27" class="0">
 <segment>
 <pinref part="SW07" gate="G$1" pin="P1"/>
 <pinref part="D7" gate="G$1" pin="A"/>
-<wire x1="213.36" y1="60.96" x2="213.36" y2="66.04" width="0.1524" layer="91"/>
+<wire x1="228.6" y1="48.26" x2="228.6" y2="53.34" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$30" class="0">
 <segment>
 <pinref part="SW08" gate="G$1" pin="P1"/>
 <pinref part="D8" gate="G$1" pin="A"/>
-<wire x1="236.22" y1="60.96" x2="236.22" y2="66.04" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="48.26" x2="251.46" y2="53.34" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$32" class="0">
 <segment>
-<wire x1="236.22" y1="50.8" x2="259.08" y2="50.8" width="0.1524" layer="91"/>
-<junction x="236.22" y="50.8"/>
-<wire x1="236.22" y1="50.8" x2="213.36" y2="50.8" width="0.1524" layer="91"/>
-<junction x="213.36" y="50.8"/>
-<wire x1="213.36" y1="50.8" x2="190.5" y2="50.8" width="0.1524" layer="91"/>
-<wire x1="190.5" y1="50.8" x2="190.5" y2="63.5" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="PD7(T0/OC4D/ADC10)"/>
-<wire x1="190.5" y1="63.5" x2="154.94" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="38.1" x2="274.32" y2="38.1" width="0.1524" layer="91"/>
+<junction x="251.46" y="38.1"/>
+<wire x1="251.46" y1="38.1" x2="228.6" y2="38.1" width="0.1524" layer="91"/>
+<junction x="228.6" y="38.1"/>
+<wire x1="228.6" y1="38.1" x2="205.74" y2="38.1" width="0.1524" layer="91"/>
+<wire x1="205.74" y1="38.1" x2="205.74" y2="55.88" width="0.1524" layer="91"/>
 <pinref part="D9" gate="G$1" pin="C"/>
-<wire x1="259.08" y1="50.8" x2="259.08" y2="55.88" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="38.1" x2="274.32" y2="43.18" width="0.1524" layer="91"/>
 <pinref part="D8" gate="G$1" pin="C"/>
-<wire x1="236.22" y1="55.88" x2="236.22" y2="50.8" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="43.18" x2="251.46" y2="38.1" width="0.1524" layer="91"/>
 <pinref part="D7" gate="G$1" pin="C"/>
-<wire x1="213.36" y1="55.88" x2="213.36" y2="50.8" width="0.1524" layer="91"/>
+<wire x1="228.6" y1="43.18" x2="228.6" y2="38.1" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PD7"/>
+<wire x1="170.18" y1="55.88" x2="205.74" y2="55.88" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$33" class="0">
 <segment>
 <pinref part="SW09" gate="G$1" pin="P1"/>
 <pinref part="D9" gate="G$1" pin="A"/>
-<wire x1="259.08" y1="60.96" x2="259.08" y2="66.04" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="48.26" x2="274.32" y2="53.34" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$36" class="0">
 <segment>
 <pinref part="SW10" gate="G$1" pin="P1"/>
 <pinref part="D10" gate="G$1" pin="A"/>
-<wire x1="213.36" y1="22.86" x2="213.36" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="228.6" y1="10.16" x2="228.6" y2="15.24" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$38" class="0">
 <segment>
-<wire x1="213.36" y1="12.7" x2="236.22" y2="12.7" width="0.1524" layer="91"/>
-<junction x="213.36" y="12.7"/>
-<wire x1="236.22" y1="12.7" x2="259.08" y2="12.7" width="0.1524" layer="91"/>
-<junction x="236.22" y="12.7"/>
-<wire x1="213.36" y1="12.7" x2="187.96" y2="12.7" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="PB4(PCINT4/ADC11)"/>
-<wire x1="154.94" y1="58.42" x2="187.96" y2="58.42" width="0.1524" layer="91"/>
-<wire x1="187.96" y1="58.42" x2="187.96" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="228.6" y1="0" x2="251.46" y2="0" width="0.1524" layer="91"/>
+<junction x="228.6" y="0"/>
+<wire x1="251.46" y1="0" x2="274.32" y2="0" width="0.1524" layer="91"/>
+<junction x="251.46" y="0"/>
 <pinref part="D10" gate="G$1" pin="C"/>
-<wire x1="213.36" y1="17.78" x2="213.36" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="228.6" y1="5.08" x2="228.6" y2="0" width="0.1524" layer="91"/>
 <pinref part="D11" gate="G$1" pin="C"/>
-<wire x1="236.22" y1="12.7" x2="236.22" y2="17.78" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="0" x2="251.46" y2="5.08" width="0.1524" layer="91"/>
 <pinref part="D12" gate="G$1" pin="C"/>
-<wire x1="259.08" y1="17.78" x2="259.08" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="5.08" x2="274.32" y2="0" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PB4"/>
+<wire x1="170.18" y1="93.98" x2="200.66" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="200.66" y1="93.98" x2="200.66" y2="0" width="0.1524" layer="91"/>
+<wire x1="200.66" y1="0" x2="228.6" y2="0" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$39" class="0">
 <segment>
 <pinref part="SW11" gate="G$1" pin="P1"/>
 <pinref part="D11" gate="G$1" pin="A"/>
-<wire x1="236.22" y1="22.86" x2="236.22" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="10.16" x2="251.46" y2="15.24" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$40" class="0">
 <segment>
 <pinref part="SW11" gate="G$1" pin="P0"/>
-<wire x1="248.92" y1="35.56" x2="251.46" y2="35.56" width="0.1524" layer="91"/>
+<wire x1="264.16" y1="22.86" x2="266.7" y2="22.86" width="0.1524" layer="91"/>
 <pinref part="SW02" gate="G$1" pin="P0"/>
-<wire x1="248.92" y1="149.86" x2="251.46" y2="149.86" width="0.1524" layer="91"/>
-<wire x1="251.46" y1="149.86" x2="251.46" y2="175.26" width="0.1524" layer="91"/>
+<wire x1="264.16" y1="137.16" x2="266.7" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="266.7" y1="137.16" x2="266.7" y2="162.56" width="0.1524" layer="91"/>
 <pinref part="SW05" gate="G$1" pin="P0"/>
-<wire x1="248.92" y1="111.76" x2="251.46" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="251.46" y1="149.86" x2="251.46" y2="111.76" width="0.1524" layer="91"/>
-<junction x="251.46" y="149.86"/>
+<wire x1="264.16" y1="99.06" x2="266.7" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="266.7" y1="137.16" x2="266.7" y2="99.06" width="0.1524" layer="91"/>
+<junction x="266.7" y="137.16"/>
 <pinref part="SW08" gate="G$1" pin="P0"/>
-<wire x1="248.92" y1="73.66" x2="251.46" y2="73.66" width="0.1524" layer="91"/>
-<wire x1="251.46" y1="111.76" x2="251.46" y2="73.66" width="0.1524" layer="91"/>
-<junction x="251.46" y="111.76"/>
-<wire x1="251.46" y1="35.56" x2="251.46" y2="73.66" width="0.1524" layer="91"/>
-<junction x="251.46" y="73.66"/>
-<wire x1="251.46" y1="175.26" x2="193.04" y2="175.26" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="PB6(PCINT6/OC1B/OC4B/ADC13)"/>
-<wire x1="154.94" y1="53.34" x2="193.04" y2="53.34" width="0.1524" layer="91"/>
-<wire x1="193.04" y1="53.34" x2="193.04" y2="175.26" width="0.1524" layer="91"/>
+<wire x1="264.16" y1="60.96" x2="266.7" y2="60.96" width="0.1524" layer="91"/>
+<wire x1="266.7" y1="99.06" x2="266.7" y2="60.96" width="0.1524" layer="91"/>
+<junction x="266.7" y="99.06"/>
+<wire x1="266.7" y1="22.86" x2="266.7" y2="60.96" width="0.1524" layer="91"/>
+<junction x="266.7" y="60.96"/>
+<wire x1="266.7" y1="162.56" x2="208.28" y2="162.56" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PB6"/>
+<wire x1="170.18" y1="88.9" x2="208.28" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="208.28" y1="88.9" x2="208.28" y2="162.56" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$42" class="0">
 <segment>
 <pinref part="SW12" gate="G$1" pin="P1"/>
 <pinref part="D12" gate="G$1" pin="A"/>
-<wire x1="259.08" y1="27.94" x2="259.08" y2="22.86" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="15.24" x2="274.32" y2="10.16" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$4" class="0">
 <segment>
-<pinref part="U$1" gate="G$1" pin="PE2(!HWB)"/>
-<wire x1="93.98" y1="45.72" x2="96.52" y2="45.72" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="PE2"/>
+<wire x1="170.18" y1="50.8" x2="187.96" y2="50.8" width="0.1524" layer="91"/>
+<wire x1="187.96" y1="50.8" x2="187.96" y2="48.26" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="2"/>
 </segment>
 </net>
@@ -11706,95 +11900,94 @@ In this library the device names are the same as the pin names of the symbols, t
 <pinref part="USB1" gate="G$1" pin="SHIELD@1"/>
 <pinref part="USB1" gate="G$1" pin="SHIELD@3"/>
 <pinref part="USB1" gate="G$1" pin="SHIELD@4"/>
-<wire x1="-30.48" y1="88.9" x2="-30.48" y2="86.36" width="0.1524" layer="91"/>
-<junction x="-30.48" y="86.36"/>
+<wire x1="27.94" y1="99.06" x2="27.94" y2="96.52" width="0.1524" layer="91"/>
+<junction x="27.94" y="96.52"/>
 <pinref part="USB1" gate="G$1" pin="SHIELD@2"/>
-<wire x1="-30.48" y1="83.82" x2="-30.48" y2="86.36" width="0.1524" layer="91"/>
-<junction x="-30.48" y="83.82"/>
+<wire x1="27.94" y1="93.98" x2="27.94" y2="96.52" width="0.1524" layer="91"/>
+<junction x="27.94" y="93.98"/>
 <pinref part="F1" gate="G$1" pin="P$2"/>
-<wire x1="-30.48" y1="81.28" x2="-30.48" y2="83.82" width="0.1524" layer="91"/>
-<wire x1="-30.48" y1="83.82" x2="-45.72" y2="83.82" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="91.44" x2="27.94" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="93.98" x2="12.7" y2="93.98" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="GND" class="0">
 <segment>
 <pinref part="SUPPLY10" gate="GND" pin="GND"/>
 <pinref part="F1" gate="G$1" pin="P$1"/>
-<wire x1="-45.72" y1="55.88" x2="-45.72" y2="58.42" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="66.04" x2="12.7" y2="68.58" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="C7" gate="G$1" pin="2"/>
 <pinref part="C9" gate="G$1" pin="2"/>
-<wire x1="58.42" y1="0" x2="50.8" y2="0" width="0.1524" layer="91"/>
-<junction x="50.8" y="0"/>
-<wire x1="50.8" y1="0" x2="43.18" y2="0" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="35.56" x2="43.18" y2="35.56" width="0.1524" layer="91"/>
+<junction x="43.18" y="35.56"/>
+<wire x1="43.18" y1="35.56" x2="35.56" y2="35.56" width="0.1524" layer="91"/>
 <pinref part="C6" gate="G$1" pin="2"/>
-<junction x="43.18" y="0"/>
-<wire x1="43.18" y1="0" x2="35.56" y2="0" width="0.1524" layer="91"/>
+<junction x="35.56" y="35.56"/>
+<wire x1="35.56" y1="35.56" x2="27.94" y2="35.56" width="0.1524" layer="91"/>
 <pinref part="C5" gate="G$1" pin="2"/>
-<junction x="35.56" y="0"/>
-<wire x1="35.56" y1="0" x2="27.94" y2="0" width="0.1524" layer="91"/>
+<junction x="27.94" y="35.56"/>
+<wire x1="27.94" y1="35.56" x2="20.32" y2="35.56" width="0.1524" layer="91"/>
 <pinref part="C4" gate="G$1" pin="2"/>
-<junction x="27.94" y="0"/>
-<wire x1="27.94" y1="0" x2="20.32" y2="0" width="0.1524" layer="91"/>
+<junction x="20.32" y="35.56"/>
+<wire x1="20.32" y1="35.56" x2="12.7" y2="35.56" width="0.1524" layer="91"/>
 <pinref part="C3" gate="G$1" pin="2"/>
-<junction x="20.32" y="0"/>
-<wire x1="20.32" y1="-2.54" x2="20.32" y2="0" width="0.1524" layer="91"/>
+<junction x="12.7" y="35.56"/>
+<wire x1="12.7" y1="33.02" x2="12.7" y2="35.56" width="0.1524" layer="91"/>
 <pinref part="SUPPLY2" gate="GND" pin="GND"/>
 </segment>
 <segment>
 <pinref part="USB1" gate="G$1" pin="GND"/>
-<wire x1="-22.86" y1="76.2" x2="-5.08" y2="76.2" width="0.1524" layer="91"/>
-<wire x1="-5.08" y1="76.2" x2="43.18" y2="76.2" width="0.1524" layer="91"/>
-<wire x1="-5.08" y1="76.2" x2="-5.08" y2="73.66" width="0.1524" layer="91"/>
-<junction x="-5.08" y="76.2"/>
-<wire x1="-5.08" y1="73.66" x2="5.08" y2="73.66" width="0.1524" layer="91"/>
-<wire x1="5.08" y1="73.66" x2="55.88" y2="73.66" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="86.36" x2="55.88" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="55.88" y1="86.36" x2="83.82" y2="86.36" width="0.1524" layer="91"/>
+<junction x="55.88" y="86.36"/>
+<wire x1="55.88" y1="86.36" x2="55.88" y2="81.28" width="0.1524" layer="91"/>
 <pinref part="SUPPLY7" gate="GND" pin="GND"/>
-<junction x="5.08" y="73.66"/>
-<pinref part="U$1" gate="G$1" pin="GND@43"/>
-<wire x1="96.52" y1="27.94" x2="93.98" y2="27.94" width="0.1524" layer="91"/>
-<wire x1="93.98" y1="27.94" x2="93.98" y2="30.48" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="GND@35"/>
-<wire x1="96.52" y1="30.48" x2="93.98" y2="30.48" width="0.1524" layer="91"/>
-<junction x="93.98" y="30.48"/>
-<wire x1="93.98" y1="30.48" x2="93.98" y2="33.02" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="GND@23"/>
-<wire x1="96.52" y1="33.02" x2="93.98" y2="33.02" width="0.1524" layer="91"/>
-<junction x="93.98" y="33.02"/>
-<wire x1="93.98" y1="33.02" x2="93.98" y2="35.56" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="GND@15"/>
-<wire x1="96.52" y1="35.56" x2="93.98" y2="35.56" width="0.1524" layer="91"/>
-<junction x="93.98" y="35.56"/>
-<wire x1="93.98" y1="35.56" x2="93.98" y2="38.1" width="0.1524" layer="91"/>
-<wire x1="93.98" y1="38.1" x2="55.88" y2="38.1" width="0.1524" layer="91"/>
-<wire x1="55.88" y1="73.66" x2="55.88" y2="38.1" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="UGND"/>
-<wire x1="96.52" y1="38.1" x2="93.98" y2="38.1" width="0.1524" layer="91"/>
-<junction x="93.98" y="38.1"/>
 <pinref part="C8" gate="G$1" pin="2"/>
 </segment>
 <segment>
-<wire x1="12.7" y1="35.56" x2="12.7" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="43.18" x2="88.9" y2="43.18" width="0.1524" layer="91"/>
 <pinref part="SUPPLY1" gate="GND" pin="GND"/>
-<wire x1="12.7" y1="33.02" x2="20.32" y2="33.02" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="35.56" x2="27.94" y2="33.02" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="33.02" x2="20.32" y2="33.02" width="0.1524" layer="91"/>
-<junction x="20.32" y="33.02"/>
+<wire x1="88.9" y1="43.18" x2="88.9" y2="35.56" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="27.94" x2="88.9" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="88.9" y1="27.94" x2="88.9" y2="35.56" width="0.1524" layer="91"/>
+<junction x="88.9" y="35.56"/>
 <pinref part="Y1" gate="G$1" pin="GND"/>
-<wire x1="20.32" y1="43.18" x2="20.32" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="99.06" y1="35.56" x2="88.9" y2="35.56" width="0.1524" layer="91"/>
 <pinref part="C1" gate="G$1" pin="1"/>
 <pinref part="C2" gate="G$1" pin="1"/>
 </segment>
 <segment>
 <pinref part="SUPPLY5" gate="GND" pin="GND"/>
-<wire x1="20.32" y1="99.06" x2="22.86" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="83.82" y1="106.68" x2="86.36" y2="106.68" width="0.1524" layer="91"/>
 <pinref part="SW00" gate="G$1" pin="1"/>
 </segment>
 <segment>
 <pinref part="SUPPLY6" gate="GND" pin="GND"/>
-<wire x1="81.28" y1="45.72" x2="83.82" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="187.96" y1="30.48" x2="187.96" y2="38.1" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="1"/>
+</segment>
+<segment>
+<pinref part="SUPPLY9" gate="GND" pin="GND"/>
+<wire x1="116.84" y1="35.56" x2="116.84" y2="45.72" width="0.1524" layer="91"/>
+<pinref part="U1" gate="A" pin="GND_3"/>
+<pinref part="U1" gate="A" pin="GND_2"/>
+<wire x1="134.62" y1="50.8" x2="129.54" y2="50.8" width="0.1524" layer="91"/>
+<wire x1="129.54" y1="50.8" x2="129.54" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="129.54" y1="48.26" x2="134.62" y2="48.26" width="0.1524" layer="91"/>
+<junction x="129.54" y="48.26"/>
+<pinref part="U1" gate="A" pin="GND_4"/>
+<wire x1="134.62" y1="45.72" x2="129.54" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="129.54" y1="45.72" x2="129.54" y2="48.26" width="0.1524" layer="91"/>
+<junction x="129.54" y="45.72"/>
+<pinref part="U1" gate="A" pin="GND"/>
+<wire x1="134.62" y1="43.18" x2="129.54" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="129.54" y1="43.18" x2="129.54" y2="45.72" width="0.1524" layer="91"/>
+<junction x="129.54" y="43.18"/>
+<pinref part="U1" gate="A" pin="UGND"/>
+<wire x1="134.62" y1="40.64" x2="129.54" y2="40.64" width="0.1524" layer="91"/>
+<wire x1="129.54" y1="40.64" x2="129.54" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="45.72" x2="129.54" y2="45.72" width="0.1524" layer="91"/>
 </segment>
 </net>
 </nets>


### PR DESCRIPTION
# :green_heart: v20190608

## Motivation

The choice of components in the first version made hand soldering very difficult. Despite reviewing the board and looking at the gerber files, I did not realize that I was using metric 0603 diodes. They were tiny, and impossible for me to solder with an iron. With the tools on hand, I was unable to see the orientation indicators. This update moves major components to larger sizes for easier hand soldering.

## Organization

I now have mixed component types. I am using through-hole components for the switches and switch matrix, and surface mount components for the rest of the board. The through hole diodes will make probing with an oscilloscope much easier during initial construction, and the components will be hidden by the switches and keycaps.

Around the chip I am still using surface mount components because of the available physical space. I would prefer all through-hole for aesthetic reasons, but I do not have enough space in a perfectly square 76mm x 76mm board.

## Changes

* Changed ATMEGA package from QFN to TQFP
* Increased crystal package size from 3.2x2.5 to 3.2x5
* Replaced 0603 (metric) diodes with through-hole 1N4148 diodes
* Rerouted and updated board accordingly
* Added *.cam file of consistent export settings
* Updated and expanded information in the BOM